### PR TITLE
Add fedmenu popup.

### DIFF
--- a/config.cfg.template
+++ b/config.cfg.template
@@ -69,6 +69,14 @@ config = {
     "frontend": {
         "packages_per_page": 100,
         "builds_per_page": 15,
+
+        # Production copies for fedmenu
+        #"fedmenu_url": "https://apps.fedoraproject.org/fedmenu",
+        #"fedmenu_data_url": "https://apps.fedoraproject.org/js/data.js",
+
+        # Development copies for fedmenu
+        #"fedmenu_url": "http://threebean.org/fedmenu",
+        #"fedmenu_data_url": "http://threebean.org/fedmenu/dev-data.js",
     },
     "alembic": {
         "alembic_ini": "@DATADIR@/alembic.ini"

--- a/koschei/views.py
+++ b/koschei/views.py
@@ -171,6 +171,17 @@ def inject_times():
     return {'since': datetime.min, 'until': datetime.now()}
 
 
+@app.context_processor
+def inject_fedmenu():
+    if 'fedmenu_url' in frontend_config:
+        return {
+            'fedmenu_url': frontend_config['fedmenu_url'],
+            'fedmenu_data_url': frontend_config['fedmenu_data_url'],
+        }
+    else:
+        return {}
+
+
 @app.route('/')
 @tab('Packages')
 def frontpage():

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,6 +7,22 @@
 <title>{% block title %}Koschei{% endblock %}</title>
 <link rel="stylesheet" type="text/css" media="screen" title="Koji Style"
 href="{{ url_for('static', filename='koji.css') }}"/>
+
+{% if fedmenu_url is defined %}
+<script src="{{fedmenu_url}}/js/jquery-1.11.2.min.js"></script>
+<script src="{{fedmenu_url}}/js/fedmenu.js"></script>
+<script>
+  fedmenu({
+      'url': '{{fedmenu_data_url}}',
+      'mimeType': 'application/javascript',
+      'position': 'bottom-right',
+      {% if package is defined %}
+      'package': '{{ package.name }}',
+      {% endif %}
+  });
+</script>
+{% endif %}
+
 </head>
 <body>
 <div id="wrap">


### PR DESCRIPTION
This adds [the fedmenu menu](https://github.com/fedora-infra/fedmenu) if configured.  If not configured, it should add nothing new to the pages served by koschei.

[Adding fedmenu to all our apps](https://fedoraproject.org/wiki/Infrastructure/FY16_frontend) is one of the infrastructure team's FY16 goals.