### PR TITLE
Delete builds that failed due to Koji faults

### DIFF
--- a/koschei/backend.py
+++ b/koschei/backend.py
@@ -149,6 +149,12 @@ class Backend(object):
                 self.db.commit()
                 return
             assert state in (Build.COMPLETE, Build.FAILED)
+            if util.is_koji_fault(self.koji_sessions['primary'], build.task_id):
+                self.log.info('Deleting build {0} because it ended with Koji fault'
+                              .format(build))
+                self.db.delete(build)
+                self.db.commit()
+                return
             self.log.info('Setting build {build} state to {state}'
                           .format(build=build,
                                   state=Build.REV_STATE_MAP[state]))

--- a/koschei/util.py
+++ b/koschei/util.py
@@ -256,6 +256,16 @@ def koji_scratch_build(session, name, source, build_opts):
     return task_id
 
 
+def is_koji_fault(session, task_id):
+    """
+    Return true iff specified finished Koji task was ended due to Koji fault.
+    """
+    try:
+        session.getTaskResult(task_id)
+        return False
+    except koji.Fault:
+        return True
+
 def mkdir_if_absent(path):
     try:
         os.makedirs(path)


### PR DESCRIPTION
Fixes #42

This is just a proof of concept. It will need some refactoring before merging - in current shape it won't work because it uses Koji XML-RPC during itercall loop.