### PR TITLE
Schedule builds from last known SRPM

### DIFF
--- a/koschei/backend.py
+++ b/koschei/backend.py
@@ -59,9 +59,9 @@ class Backend(object):
             build_opts = {'arch_override': package.arch_override}
         # SRPMs are taken from secondary, primary needs to be able to build
         # from relative URL constructed against secondary (internal redirect)
-        srpm, srpm_url = (util.get_last_srpm(self.koji_sessions['secondary'], name) or
-                          (None, None))
-        if srpm_url:
+        srpm = package.srpm_nevra
+        if srpm:
+            srpm_url = util.get_srpm_url(srpm)
             package.manual_priority = 0
             build.task_id = util.koji_scratch_build(self.koji_sessions['primary'], name,
                                                     srpm_url, build_opts)

--- a/koschei/models.py
+++ b/koschei/models.py
@@ -156,11 +156,12 @@ class Package(Base):
         return self.last_build_id != self.last_complete_build_id
 
     @property
-    def srpm_nvra(self):
+    def srpm_nevra(self):
         return dict(name=self.name,
+                    epoch=self.last_complete_build.epoch,
                     version=self.last_complete_build.version,
                     release=self.last_complete_build.release,
-                    arch='src')
+                    arch='src') if self.last_complete_build else None
 
     def __repr__(self):
         return '{0.id} (name={0.name})'.format(self)
@@ -299,9 +300,10 @@ class Build(Base):
         return self.REV_STATE_MAP[self.state]
 
     @property
-    def srpm_nvra(self):
+    def srpm_nevra(self):
         # pylint:disable=no-member
         return dict(name=self.package.name,
+                    epoch=self.epoch,
                     version=self.version,
                     release=self.release,
                     arch='src')

--- a/koschei/resolver.py
+++ b/koschei/resolver.py
@@ -263,7 +263,7 @@ class GenerateRepoTask(AbstractResolverTask):
         packages = self.get_packages(require_build=True)
         repo = Repo(repo_id=repo_id)
         brs = util.get_rpm_requires(self.koji_sessions['secondary'],
-                                    [p.srpm_nvra for p in packages])
+                                    [p.srpm_nevra for p in packages])
         brs = util.parallel_generator(brs, queue_size=None)
         try:
             with self.repo_cache.get_sack(repo_descriptor) as sack:

--- a/koschei/util.py
+++ b/koschei/util.py
@@ -203,17 +203,9 @@ def prepare_build_opts(opts=None):
     return build_opts
 
 
-def get_last_srpm(koji_session, name):
+def get_srpm_url(srpm):
     rel_pathinfo = koji.PathInfo(topdir=primary_koji_config['srpm_relative_path_root'])
-    info = koji_session.listTagged(source_tag, latest=True,
-                                   package=name, inherit=True)
-    if info:
-        srpms = koji_session.listRPMs(buildID=info[0]['build_id'],
-                                      arches='src')
-        if srpms:
-            return (srpms[0],
-                    rel_pathinfo.build(info[0]) + '/' +
-                    rel_pathinfo.rpm(srpms[0]))
+    return rel_pathinfo.build(srpm) + '/' + rel_pathinfo.rpm(srpm)
 
 
 def koji_scratch_build(session, name, source, build_opts):

--- a/koschei/views.py
+++ b/koschei/views.py
@@ -608,7 +608,7 @@ def bugreport(name):
                 .filter(Package.last_complete_build_id != None)\
                 .options(joinedload(Package.last_complete_build))\
                 .first() or abort(404)
-    srpm = package.srpm_nvra
+    srpm = package.srpm_nevra or abort(404)
     template = util.config['bugreport']['template']
     bug = {key: template[key].format(**srpm) for key in template.keys()}
     bug['comment'] = dedent(bug['comment']).strip()


### PR DESCRIPTION
Since Fedora 24 branching, rawhide (f25) doesn't inherit from branched
(f24) any longer, see [1,2].  This means that packages that failed to
build during mass rebuild won't have SRPM tagged into f25 and Koschei
wouldn't be able to schedule scratch builds for them.  With this
change, Koschei will run builds from last known SRPM (possibly from
Fedora 24).

This change also makes submitting builds a bit faster as two Koji
queries are avoided.

[1] https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/message/GXVKAAFY3EDQMNGCSJPNQRSLEONCB2MH/
[2] http://koji.fedoraproject.org/koji/taginfo?tagID=f25