### PR TITLE
Run postgres tests during rpmbuild

### DIFF
--- a/koschei.spec
+++ b/koschei.spec
@@ -23,6 +23,7 @@ BuildRequires:       python-librepo
 BuildRequires:       rpm-python
 BuildRequires:       fedmsg
 BuildRequires:       python-psycopg2
+BuildRequires:       postgresql-server
 %endif
 
 %description
@@ -131,7 +132,11 @@ ln -s %{_bindir}/python %{buildroot}%{_libexecdir}/%{name}/koschei-resolver
 
 %if %{with tests}
 %check
-%{__python2} setup.py test
+DB=$PWD/test/db
+pg_ctl -s -w -D $DB init -o "-N -A trust"
+pg_ctl -s -w -D $DB start -o "-F -h '' -k $DB"
+TEST_WITH_POSTGRES=1 POSTGRES_HOST=$DB %{__python2} setup.py test
+pg_ctl -s -w -D $DB stop -m immediate
 %endif
 
 %pre common


### PR DESCRIPTION
Since we support more than one distro now and want to build in Copr instead of Jenkins, it would be nice to run all test (incl. PostgreSQL ones) during RPM build.

PostgreSQL server does not need to be configured or started. `%check` will create an empty database, start the server and shut it down.