### PR TITLE
Delegate user authentication to httpd

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Python code dependencies:
 - alembic
 - fedmsg
 - flask
-- flask-openid
 - flask-sqlalchemy
 - hawkey
 - jinja2

--- a/aux/test-config.cfg
+++ b/aux/test-config.cfg
@@ -63,10 +63,6 @@ config = {
         "fedmenu_data_url": "http://threebean.org/fedmenu/dev-data.js",
         "auto_tracking": True,
     },
-    "openid": {
-        "openid_provider": "id.stg.fedoraproject.org",
-        "openid_store": "/tmp/openid",
-    },
     "pkgdb": {
         "sync_tracked": True,
     },

--- a/config.cfg.template
+++ b/config.cfg.template
@@ -193,6 +193,20 @@ config = {
         # you'll want to set this to True to disable manual adding of packages
         "auto_tracking": False,
 
+        # authentication settings
+        "auth": {
+            # Regular expression used to match user identity (OpenID
+            # identifier, KRB5 principal etc.) to user name.  Identity
+            # must match this regex as a whole, user name is is
+            # content of group.
+            # Password-based auth or no auth
+            "user_re": "(.+)",
+            # Fedora OpenID
+            #"user_re": "http://(.+)\\.id\\.fedoraproject\\.org/",
+            # Kerberos
+            #"user_re": "(.+)@EXAMPLE\\.COM",
+        }
+
         # Production copies for fedmenu
         #"fedmenu_url": "https://apps.fedoraproject.org/fedmenu",
         #"fedmenu_data_url": "https://apps.fedoraproject.org/js/data.js",
@@ -204,11 +218,6 @@ config = {
     "alembic": {
         # path to alembic.ini
         "alembic_ini": "@DATADIR@/alembic.ini"
-    },
-    # openid authentication configuration
-    "openid": {
-        "openid_provider": "id.fedoraproject.org",
-        "openid_store": "@STATEDIR@/openid",
     },
     # logging configuration, passed directly to logging.config.dictConfig
     # see python logging documentation for possible values

--- a/httpd.conf
+++ b/httpd.conf
@@ -14,4 +14,14 @@
         AllowOverride All
         Require all granted
     </Directory>
+
+    <Location /login>
+        #Require valid-user
+        # Fedora OpenID
+        #AuthType OpenID
+        #AuthOpenIDSingleIdP https://id.fedoraproject.org/
+        # Kerberos
+        #AuthType GSSAPI
+        #GssapiCredStore keytab:/etc/krb5.keytab
+    </Location>
 </VirtualHost>

--- a/koschei.spec
+++ b/koschei.spec
@@ -27,7 +27,6 @@ BuildRequires:       python-psycopg2
 BuildRequires:       postgresql-server
 BuildRequires:       python-flask
 BuildRequires:       python-flask-sqlalchemy
-BuildRequires:       python-flask-openid
 BuildRequires:       python-flask-wtf
 BuildRequires:       python-jinja2
 BuildRequires:       python-dogpile-cache
@@ -66,7 +65,6 @@ Summary:        Web frontend for koschei using mod_wsgi
 Requires:       %{name}-common = %{version}-%{release}
 Requires:       python-flask
 Requires:       python-flask-sqlalchemy
-Requires:       python-flask-openid
 Requires:       python-flask-wtf
 Requires:       python-jinja2
 Requires:       mod_wsgi


### PR DESCRIPTION
Initial implementation of pluggable authentication. Users are now authenticated by httpd, which supports numerous protocols, including OpenID, GSSAPI, SAML, PAM and password-based auth.

I've tested it with OpenID and Kerberos.