### PR TITLE
Hide empty collection columns of package table

### DIFF
--- a/koschei.spec
+++ b/koschei.spec
@@ -69,6 +69,7 @@ Requires:       python-flask-wtf
 Requires:       python-jinja2
 Requires:       mod_wsgi
 Requires:       httpd
+Requires:       js-jquery
 
 %description frontend
 %{summary}.

--- a/static/jquery.min.js
+++ b/static/jquery.min.js
@@ -1,0 +1,1 @@
+/usr/share/web-assets/jquery/latest/jquery.min.js

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,6 +7,24 @@
         href="{{ url_for('static', filename='koschei.css') }}"/>
 
         <script type="text/javascript" src="{{ url_for('static', filename='jquery.min.js') }}"></script>
+        <script type="text/javascript">
+            $(function() {
+                // Hide empty collection columns of package table
+                $('.package-table th').each(function(i) {
+                    if (this.classList.contains('collection-column')) {
+                        var columnCells = $(this).parents('table').find('tr td:nth-child(' + (i + 1) + ')')
+                        var columnEmpty = true;
+                        columnCells.each(function() {
+                            columnEmpty &= this.innerHTML == '';
+                        });
+                        if (columnEmpty) {
+                            $(this).hide();
+                            columnCells.hide();
+                        }
+                    }
+                });
+            });
+        </script>
 
         {% if fedmenu_url is defined %}
         <script type="text/javascript" src="{{fedmenu_url}}/js/fedmenu.js"></script>

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,8 +6,9 @@
         <link rel="stylesheet" type="text/css" media="screen" title="Koschei Style"
         href="{{ url_for('static', filename='koschei.css') }}"/>
 
+        <script type="text/javascript" src="{{ url_for('static', filename='jquery.min.js') }}"></script>
+
         {% if fedmenu_url is defined %}
-        <script type="text/javascript" src="{{fedmenu_url}}/js/jquery-1.11.2.min.js"></script>
         <script type="text/javascript" src="{{fedmenu_url}}/js/fedmenu.js"></script>
         <script type="text/javascript" src="{{fedmenu_url}}/js/fedora-libravatar.js"></script>
         <script type="text/javascript">

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -36,13 +36,13 @@
 {{ pagination_row(page, 'Packages') }}
 {% endif %}
 <input type="hidden" name="next" value="{{ request.url }}"/>
-<table class="data-list">
+<table class="data-list package-table">
     <thead>
         <tr class="list-header">
             {{ ordered_column('name', 'Name', order) }}
             {% if not collection %}
             {% for coll in g.collections %}
-            <th>{{ coll }}</th>
+            <th class="collection-column">{{ coll }}</th>
             {% endfor %}
             {% else %}
             {{ ordered_column('state', 'State', order) }}


### PR DESCRIPTION
In package tables (all collections mode), when the whole collection column is empty, it is hidden on client-side by JavaScript code.

Think of SCLs, there are multiple collections, but packages usually belong to two of them (RHEL 6/7). It's annoying to see many empty collection columns, especially when viewing group specific to one SCL.