### PR TITLE
Parallel repo cache

### DIFF
--- a/aux/test.ipy
+++ b/aux/test.ipy
@@ -7,6 +7,7 @@ from datetime import datetime
 from sqlalchemy import *
 from sqlalchemy.orm import *
 from koschei import util
+from koschei.util import *
 from koschei import plugin
 from koschei.db import *
 from koschei.models import *

--- a/koschei/backend/file_cache.py
+++ b/koschei/backend/file_cache.py
@@ -1,0 +1,229 @@
+# Copyright (C) 2014-2016 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Author: Michael Simacek <msimacek@redhat.com>
+
+import logging
+import os
+import shutil
+import json
+import contextlib
+
+from koschei.util import FileLock
+
+
+class CacheVersionMismatch(Exception):
+    pass
+
+
+class CacheExhaustedException(Exception):
+    pass
+
+
+class FileCache(object):
+    """
+    Abstract cache of files/directories on disk. Allows concurrent access using
+    POSIX file locks.
+
+    Specializations need to override read_item and create_item methods.
+
+    Algorithm notes and invariants:
+    - entries are stored in an index file
+    - an item can be in two states
+        - "preparing" - being prepared. It only serves as a placeholder that
+          reserves capacity
+        - "ready" - ready for being used
+    - item locking - locking item ensures that it doesn't change
+      state while being inspected:
+      - if it's marked as ready, it can be safely read and used
+      - if it's marked as preparing or not present in index at all,
+        then it's invalid and should be deleted
+    - index file is locked to ensure transactionality of operations,
+      but it's not a global lock for the cache
+    - never block on item lock while holding index lock
+    """
+
+    INDEX_VERSION = 1
+
+    def __init__(self, cachedir, capacity, log=None):
+        self.log = log or logging.getLogger('koschei.file_cache.FileCache')
+        self._cachedir = cachedir
+        self._capacity = capacity
+
+    def read_item(self, cache_key, cachedir):
+        """
+        Reads and returns item with given key from cache. Will be called with
+        read lock held.
+        """
+        raise NotImplementedError()
+
+    def create_item(self, cache_key, cachedir):
+        """
+        Creates item with given key on disk in cachedir. The file/dir name must
+        be str(cache_key). Should return the item created. Will be called with
+        write lock held.
+        """
+        raise NotImplementedError()
+
+    def _p(self, filename):
+        """
+        Returns path to filename in the cache
+        """
+        return os.path.join(self._cachedir, filename)
+
+    def _read_index(self, silent=False):
+        """
+        Reads entries from index file. If the file is invalid or of older
+        version, returns empty dict (which will later on cause cache discard)
+        Expects the index to be read locked already.
+        """
+        index_path = self._p('index.json')
+        entries = {}
+        if os.path.exists(index_path):
+            with open(index_path) as index:
+                try:
+                    index_content = json.load(index)
+                    if index_content['version'] > self.INDEX_VERSION:
+                        raise CacheVersionMismatch(
+                            "Cache index version is newer than current"
+                        )
+                    elif index_content['version'] < self.INDEX_VERSION:
+                        if not silent:
+                            self.log.info("Cache index version is old. "
+                                          "Discarding cache")
+                    else:
+                        entries = index_content['entries']
+                except CacheVersionMismatch as e:
+                    raise
+                except Exception as e:
+                    if not silent:
+                        self.log.warn(
+                            "Cannot parse cache index %s, discarding cache",
+                            e,
+                        )
+        return entries
+
+    def _write_index(self, entries):
+        """
+        Writes entries to the index file.
+        Expects it to be exclusively locked already.
+        """
+        index_path = self._p('index.json')
+        with open(index_path + '.tmp', 'w') as index:
+            json.dump(dict(version=self.INDEX_VERSION, entries=entries),
+                      index, indent=True)
+        # would need fsync (or O_PONIES) to be truly atomic, but it's just a cache
+        os.rename(index_path + '.tmp', index_path)
+
+    def _cleanup_items(self, entries, exclude):
+        """
+        Removes all directories that can be locked and don't have corresponding
+        entries in ready state.
+        Expects index to be exclusively locked. Writes to index file.
+        """
+        dirents = [d for d in os.listdir(self._cachedir)
+                   if os.path.isdir(self._p(d)) and not d == exclude]
+        for dirent in dirents:
+            if entries.get(dirent) != 'ready':
+                with FileLock(self._cachedir, dirent, exclusive=True,
+                              immediate=False) as lock:
+                    if lock.try_lock():
+                        entries.pop(dirent, None)
+                        self._write_index(entries)  # preserve atomicity
+                        self.log.info("Deleting %s", dirent)
+                        shutil.rmtree(self._p(dirent), ignore_errors=True)
+        self._write_index(entries)
+
+    @contextlib.contextmanager
+    def get_item(self, cache_key):
+        key = str(cache_key)
+
+        while True:
+            with FileLock(self._cachedir, key, exclusive=True) as item_lock:
+                with FileLock(self._cachedir, 'index', exclusive=True) as index_lock:
+                    entries = self._read_index()
+                    entry = entries.get(key)
+                    if entry and entry == 'ready':
+                        # other process added it in the meantime
+                        index_lock.unlock()
+                        # relax the item lock to shared
+                        item_lock.lock(exclusive=False)
+                        # I haven't found any documentation guaranteeing
+                        # relocking to be atomic, so I must assume it isn't
+                        index_lock.lock(exclusive=False)
+                        entry = self._read_index(silent=True).get(key)
+                        if entry and entry == 'ready':
+                            index_lock.unlock()
+                            yield self.read_item(cache_key, self._cachedir)
+                            return
+                        # we lost it during relocking
+                        continue
+                    entries.pop(key, None)
+                    # ok, it's definitely not there, we have to add it
+                    if len(entries) >= self._capacity:
+                        # discard invalid repos
+                        self._cleanup_items(entries, exclude=key)
+                    if len(entries) >= self._capacity:
+                        # discard old repos
+                        ready_repos = (k for k, v in entries.items() if v == 'ready')
+                        victims = sorted(
+                            ready_repos,
+                            key=lambda r: -os.path.getmtime(self._p(r))
+                        )[:len(entries) - self._capacity + 1]
+                        for victim in victims:
+                            del entries[victim]
+                        if victims:
+                            # will delete unreferenced items from disk
+                            self._cleanup_items(entries, exclude=key)
+
+                    if len(entries) >= self._capacity:
+                        raise CacheExhaustedException(
+                            "Cannot free space for new cache item. "
+                            "Increase the cache size or decrease the number "
+                            "of processes using it."
+                        )
+
+                    # we have capacity - add new item
+                    entries[key] = 'preparing'
+                    self._write_index(entries)
+                    index_lock.unlock()
+
+                    # perform preparation
+                    item = self.create_item(cache_key, self._cachedir)
+
+                    # register item as ready (if it is)
+                    index_lock.lock()
+                    entries = self._read_index()
+                    if item:
+                        entries[key] = 'ready'
+                        self._write_index(entries)
+                    else:
+                        entries.pop(key)
+                        self._write_index(entries)
+                        shutil.rmtree(self._p(key), ignore_errors=True)
+                        yield None
+                        return
+                    index_lock.unlock()
+                    # relax the item lock to shared
+                    item_lock.lock(exclusive=False)
+                    index_lock.lock(exclusive=False)
+                    entry = self._read_index(silent=True).get(key)
+                    if entry and entry == 'ready':
+                        index_lock.unlock()
+                        yield item
+                        return
+                    # while unlikely, we lost the item while relocking
+                    continue

--- a/koschei/backend/repo_cache.py
+++ b/koschei/backend/repo_cache.py
@@ -21,115 +21,47 @@ from __future__ import print_function, absolute_import
 
 import logging
 import os
-import shutil
-from collections import OrderedDict
-
-import hawkey
-import librepo
+import contextlib
 
 from koschei.config import get_config
-from koschei.backend.repo_util import KojiRepoDescriptor
-
-log = logging.getLogger('koschei.repo_cache')
-
-REPO_404 = 19
+from koschei.backend import repo_util
+from koschei.backend.file_cache import FileCache
 
 
-class RepoCache(object):
+class CacheVersionMismatch(Exception):
+    pass
+
+
+class RepoCache(FileCache):
+    """
+    Cache of repo files. Allows concurrent access from multiple processes, but
+    not threads.
+    """
     def __init__(self):
-        self._repos_dir = os.path.join(get_config('directories.cachedir'), 'repodata')
-        self._capacity = get_config('dependency.cache_l2_capacity')
-        self._repos = OrderedDict()
+        self.log = logging.getLogger('koschei.repo_cache.RepoCache')
+        super(RepoCache, self).__init__(
+            cachedir=os.path.join(get_config('directories.cachedir'), 'repodata'),
+            capacity=get_config('dependency.cache_l2_capacity'),
+            log=self.log,
+        )
 
-        for repo_descriptor, repo_path in sorted(self._read_cache()):
-            self._ensure_capacity()
-            self._repos[repo_descriptor] = repo_path
-        log.debug('Added {} repos from disk'.format(len(self._repos)))
+    # @Override
+    def read_item(self, repo_descriptor, cachedir):
+        return repo_util.load_sack(cachedir, repo_descriptor)
 
-    def _read_cache(self):
-        """ Read cached repos from disk. Remove directories which names
-        are not parseable as repo descriptor strings. """
-        log.debug('Reading cached repos from disk...')
-        for repo_descriptor, repo_path in [(KojiRepoDescriptor.from_string(repo_name),
-                                            os.path.join(self._repos_dir, repo_name))
-                                           for repo_name in os.listdir(self._repos_dir)]:
-            if repo_descriptor:
-                yield repo_descriptor, repo_path
-            elif os.path.exists(repo_path):
-                # Remove directories that don't look like valid repos,
-                # such as incomplete downloads.
-                shutil.rmtree(repo_path)
-                log.debug('Removed bogus file from cache: {}'.format(repo_path))
+    # @Override
+    def create_item(self, repo_descriptor, cachedir):
+        self.log.info('Downloading repo {}'.format(repo_descriptor))
 
-    def _ensure_capacity(self):
-        """ Make sure there is enough room for new repo to be added. """
-        if len(self._repos) == self._capacity:
-            # Adding repo would exceed capacity, discard LRU repo to free space.
-            _, repo_path = self._repos.popitem(last=False)
-            if os.path.exists(repo_path):
-                shutil.rmtree(repo_path)
-        assert len(self._repos) < self._capacity
-
-    def _download_repo(self, repo_descriptor, repo_dir):
-        """ Download repo from Koji to disk. """
-        h = librepo.Handle()
-        h.destdir = repo_dir
-        # pylint:disable=no-member
-        h.repotype = librepo.LR_YUMREPO
-        h.urls = [repo_descriptor.url]
-        h.yumdlist = ['primary', 'filelists', 'group', 'group_gz']
-        h.perform(librepo.Result())
-
-    def _load_sack(self, repo_descriptor, repo_path, build_cache=False):
-        """ Load repo from disk into memory as sack. """
-        cache_dir = os.path.join(repo_path, 'cache')
-        for_arch = get_config('dependency.resolve_for_arch')
-        if build_cache:
-            os.mkdir(cache_dir)
-        sack = hawkey.Sack(arch=for_arch, cachedir=cache_dir)
-        h = librepo.Handle()
-        h.local = True
-        # pylint:disable=no-member
-        h.repotype = librepo.LR_YUMREPO
-        h.urls = [repo_path]
-        h.yumdlist = ['primary', 'filelists', 'group']
-        repodata = h.perform(librepo.Result()).yum_repo
-        repo = hawkey.Repo(str(repo_descriptor))
-        repo.repomd_fn = repodata['repomd']
-        repo.primary_fn = repodata['primary']
-        repo.filelists_fn = repodata['filelists']
-        sack.load_yum_repo(repo, load_filelists=True, build_cache=build_cache)
+        sack = repo_util.load_sack(cachedir, repo_descriptor, download=True)
+        if sack:
+            self.log.info('Repo {} was successfully downloaded'
+                          .format(repo_descriptor))
+        else:
+            self.log.info('Repo {} was not found'.format(repo_descriptor))
         return sack
 
+    @contextlib.contextmanager
     def get_sack(self, repo_descriptor):
-        """ Load repo as hawkey sack.  Returns None if repo was not found on Koji.
-        Failures to load repo for any other reason are raised as exceptions.
-
-        Repos are downloaded to temporary directory, which is atomically renamed to
-        final repo directory only after sack is successfully loaded and libsolv
-        cache created. This is to make sure that nonexistent or invalid repos are
-        never present under repo_path, even if process is killed at some point.
-        """
-        repo_path = self._repos.get(repo_descriptor)
-        if repo_path:
-            # Mark repo as most-recently used by re-adding it to OrderedDict.
-            del self._repos[repo_descriptor]
-            self._repos[repo_descriptor] = repo_path
-            return self._load_sack(repo_descriptor, repo_path)
-        log.debug('Downloading repo {} (cache miss)'.format(repo_descriptor))
-        try:
-            self._ensure_capacity()
-            repo_path = os.path.join(self._repos_dir, str(repo_descriptor))
-            temp_dir = repo_path + ".tmp"
-            os.mkdir(temp_dir)
-            self._download_repo(repo_descriptor, temp_dir)
-            sack = self._load_sack(repo_descriptor, temp_dir, build_cache=True)
-            os.rename(temp_dir, repo_path)
-            self._repos[repo_descriptor] = repo_path
-            log.debug('Repo {} was successfully downloaded'.format(repo_descriptor))
-            return sack
-        except librepo.LibrepoException as e:
-            if e.args[0] == REPO_404:
-                log.debug('Repo {} was not found'.format(repo_descriptor))
-                return None
-            raise
+        with self.get_item(repo_descriptor) as sack:
+            yield sack

--- a/test/common.py
+++ b/test/common.py
@@ -29,11 +29,7 @@ import logging
 import requests
 import vcr
 import six
-
-if six.PY2:
-    from xmlrpclib import loads, dumps
-else:
-    from xmlrpc.client import loads, dumps
+import contextlib
 
 from mock import Mock
 from datetime import datetime
@@ -45,6 +41,11 @@ from koschei.models import (Package, Build, Collection, BasePackage,
                             PackageGroupRelation, PackageGroup, GroupACL, User,
                             KojiTask)
 from koschei.backend import KoscheiBackendSession, repo_util, service
+
+if six.PY2:
+    from xmlrpclib import loads, dumps
+else:
+    from xmlrpc.client import loads, dumps
 
 workdir = '.workdir'
 
@@ -340,10 +341,11 @@ class KojiMock(Mock):
 
 
 class RepoCacheMock(object):
+    @contextlib.contextmanager
     def get_sack(self, desc):
         if 123 < desc.repo_id < 130:
             desc = repo_util.KojiRepoDescriptor(desc.koji_id, desc.build_tag, 123)
-        return repo_util.load_sack(os.path.join(testdir, 'repos'), desc)
+        yield repo_util.load_sack(os.path.join(testdir, 'repos'), desc)
 
 
 def service_ctor(name, plugin_name=None, plugin_endpoint='backend'):

--- a/test/repo_cache_test.py
+++ b/test/repo_cache_test.py
@@ -18,6 +18,7 @@
 
 import contextlib
 import os
+import json
 
 import librepo
 from mock import patch
@@ -46,6 +47,11 @@ class RepoCacheTest(DBTest):
                 KojiRepoDescriptor('primary', 'build_tag', repo)
             os.makedirs(os.path.join('repodata', str(desc)))
         os.mkdir('repodata/not-repo')
+        with open('repodata/index.json', 'w') as index:
+            json.dump(dict(
+                version=repo_cache.RepoCache.INDEX_VERSION,
+                entries={str(d): 'ready' for d in self.descriptors.values()},
+            ), index)
 
     def test_read_from_disk(self):
         with mocks() as (librepo_mock, sack_mock):

--- a/test/resolver_test.py
+++ b/test/resolver_test.py
@@ -48,7 +48,8 @@ FOO_DEPS = [
 
 def get_sack():
     desc = KojiRepoDescriptor(koji_id='primary', repo_id=123, build_tag='f25-build')
-    return RepoCacheMock().get_sack(desc)
+    with RepoCacheMock().get_sack(desc) as sack:
+        return sack
 
 
 # pylint:disable=unbalanced-tuple-unpacking


### PR DESCRIPTION
I've reimplemented RepoCache such that it can be used concurrently from multiple processes. I used POSIX file locks for the implementation, which are per-process and not thread-safe, but on the other hand should work over NFS, if we ever need it.
Note that it's not LRU, to improve concurrency (and reduce complexity) I select the victim based on mtime (so it's FIFO).

@mizdebsk you're concurrency expert, could you please review it?
