### PR TITLE
Port to Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Python code dependencies:
 - psycopg2
 - rpm
 - sqlalchemy
+- six
 
 Test dependencies (optional):
 - nose

--- a/alembic/versions/42ec52bcb3b4_download_repo_id_fin.py
+++ b/alembic/versions/42ec52bcb3b4_download_repo_id_fin.py
@@ -5,6 +5,7 @@ Revises: 258ebf8f2f2a
 Create Date: 2014-08-27 22:04:17.383227
 
 """
+from __future__ import print_function
 
 # revision identifiers, used by Alembic.
 revision = '42ec52bcb3b4'
@@ -52,7 +53,7 @@ def upgrade():
         proc += len(builds)
         s.flush()
         off += step
-        print "processed {} builds".format(proc)
+        print("processed {} builds".format(proc))
 
 def downgrade():
     pass

--- a/aux/koji-load.py
+++ b/aux/koji-load.py
@@ -18,6 +18,9 @@
 #
 # Author: Mikolaj Izdebski <mizdebsk@redhat.com>
 
+from __future__ import print_function
+from six.moves import range as xrange
+
 import koji
 import sys
 from concurrent.futures import ThreadPoolExecutor
@@ -56,4 +59,4 @@ def gather_data(env):
 with ThreadPoolExecutor(max_workers=16) as executor:
     result = [f.result() for f in [executor.submit(gather_data, env) for env in sorted(koji_urls.keys())]]
     for a, b in zip(*result):
-        print "   ".join([a, b])
+        print("   ".join([a, b]))

--- a/aux/pkgdb-set-flag.py
+++ b/aux/pkgdb-set-flag.py
@@ -17,6 +17,8 @@
 #
 # Author: Mikolaj Izdebski <mizdebsk@redhat.com>
 
+from __future__ import print_function
+
 # Set Koschei monitoring flag for <PACKAGES> to <VALUE> in pkgdb2 instance at
 # <PKGDB_URL>.  Login credentials are provided in <FAS_CONF> file.
 # Requires: packagedb-cli >= 2.9.
@@ -27,7 +29,7 @@ FAS_CONF = '/etc/fas.conf'
 
 
 from pkgdb2client import PkgDB
-from ConfigParser import ConfigParser
+from six.moves.configparser import ConfigParser
 
 # Obtain FAS credentials
 conf = ConfigParser()
@@ -43,6 +45,6 @@ pkgdb.login(login, password)
 for package in PACKAGES:
     result = pkgdb.set_koschei_status(package, VALUE)
     message = result.get('messages', 'Invalid output')
-    print "%s: %s" % (package, message)
+    print("%s: %s" % (package, message))
 
-print "Done."
+print("Done.")

--- a/koschei.spec
+++ b/koschei.spec
@@ -30,6 +30,7 @@ BuildRequires:       python-flask-sqlalchemy
 BuildRequires:       python-flask-wtf
 BuildRequires:       python-jinja2
 BuildRequires:       python-dogpile-cache
+BuildRequires:       python-six
 %endif
 
 %description
@@ -42,6 +43,7 @@ provides a web interface to the results.
 Summary:        Acutual python code for koschei backend and frontend
 Requires:       python-sqlalchemy
 Requires:       python-psycopg2
+Requires:       python-six
 Requires:       rpm-python
 Requires(pre):  shadow-utils
 Obsoletes:      %{name} < 1.5.1

--- a/koschei/backend/__init__.py
+++ b/koschei/backend/__init__.py
@@ -17,7 +17,7 @@
 # Author: Michael Simacek <msimacek@redhat.com>
 
 from datetime import datetime, timedelta
-from itertools import izip
+from six.moves import zip as izip
 
 import koji
 from sqlalchemy.exc import IntegrityError
@@ -127,12 +127,12 @@ class Backend(KojiService):
             while True:
                 try:
                     build_tasks = self.sync_tasks(collection, chunk, real=True)
-                    for build, tasks in build_tasks.items():
+                    for build, tasks in list(build_tasks.items()):
                         if not build.repo_id:
                             del build_tasks[build]
-                    chunk = build_tasks.keys()
+                    chunk = list(build_tasks.keys())
                     self.db.bulk_insert(chunk)
-                    for build, tasks in build_tasks.items():
+                    for build, tasks in list(build_tasks.items()):
                         for task in tasks:
                             task.build_id = build.id
                     self.insert_koji_tasks(build_tasks)
@@ -328,7 +328,7 @@ class Backend(KojiService):
         return build_tasks
 
     def insert_koji_tasks(self, tasks):
-        tasks = [task for build_task in tasks.values() for task in build_task]
+        tasks = [task for build_task in list(tasks.values()) for task in build_task]
         build_ids = [t.build_id for t in tasks]
         if build_ids:
             assert all(build_ids)
@@ -370,7 +370,7 @@ class Backend(KojiService):
             to_add = []
             for pkg_dict in koji_packages:
                 name = pkg_dict['package_name']
-                if name not in bases.iterkeys():
+                if name not in iter(bases.keys()):
                     base = BasePackage(name=name)
                     bases[name] = base
                     to_add.append(base)

--- a/koschei/backend/services/scheduler.py
+++ b/koschei/backend/services/scheduler.py
@@ -99,7 +99,7 @@ class Scheduler(KojiService):
 
     def get_priorities(self):
         incomplete_builds = self.get_incomplete_builds_query()
-        queries = self.get_priority_queries().values()
+        queries = list(self.get_priority_queries().values())
         union_query = union_all(*queries).alias('un')
         pkg_id = union_query.c.pkg_id
         current_priority = cast(func.sum(union_query.c.priority),

--- a/koschei/config.py
+++ b/koschei/config.py
@@ -27,7 +27,7 @@ __config = {}
 
 def merge_dict(d1, d2):
     ret = d1.copy()
-    for k, v in d2.items():
+    for k, v in list(d2.items()):
         if k in ret and isinstance(v, dict) and isinstance(ret[k], dict):
             ret[k] = merge_dict(ret[k], v)
         else:
@@ -52,7 +52,7 @@ def load_config(config_paths, ignore_env=False):
             with open(config_path) as config_file:
                 code = compile(config_file.read(), config_path, 'exec')
                 conf_locals = {}
-                exec code in conf_locals
+                exec(code, conf_locals)
                 if 'config' in conf_locals:
                     return conf_locals['config']
         else:

--- a/koschei/util.py
+++ b/koschei/util.py
@@ -22,8 +22,9 @@ from __future__ import print_function
 import logging
 import rpm
 import time
+import six
 
-from Queue import Queue
+from six.moves.queue import Queue
 from threading import Thread
 
 
@@ -33,7 +34,7 @@ def chunks(seq, chunk_size=100):
         seq = seq[chunk_size:]
 
 
-class parallel_generator(object):
+class parallel_generator(six.Iterator):
     sentinel = object()
 
     def __init__(self, generator, queue_size=1000):
@@ -59,7 +60,7 @@ class parallel_generator(object):
     def __iter__(self):
         return self
 
-    def next(self):
+    def __next__(self):
         item = self.queue.get()
         if item is self.sentinel:
             raise self.worker_exception  # StopIteration in case of success

--- a/test/backend_test.py
+++ b/test/backend_test.py
@@ -18,6 +18,7 @@
 
 import koji
 import logging
+import six
 
 from copy import deepcopy
 from datetime import datetime, timedelta
@@ -64,7 +65,7 @@ class BackendTest(DBTest):
             self.assertEqual('ok', package.state_string)
             event.assert_called_once_with('package_state_change', package=package,
                                           prev_state='failing', new_state='ok')
-            self.assertItemsEqual([(x['id'],) for x in rnv_subtasks],
+            six.assertCountEqual(self, [(x['id'],) for x in rnv_subtasks],
                                   self.db.query(KojiTask.task_id))
 
     def test_update_state_existing_task(self):
@@ -90,7 +91,7 @@ class BackendTest(DBTest):
             self.assertEqual('ok', package.state_string)
             event.assert_called_once_with('package_state_change', package=package,
                                           prev_state='failing', new_state='ok')
-            self.assertItemsEqual([(x['id'],) for x in rnv_subtasks],
+            six.assertCountEqual(self, [(x['id'],) for x in rnv_subtasks],
                                   self.db.query(KojiTask.task_id))
 
     # Regression test for https://github.com/msimacek/koschei/issues/27
@@ -131,10 +132,10 @@ class BackendTest(DBTest):
                 .assert_called_once_with(rnv_build_info[0]['task_id'],
                                          request=True)
             self.assertEqual('ok', package.state_string)
-            self.assertEquals(460889, package.last_complete_build.repo_id)
+            self.assertEqual(460889, package.last_complete_build.repo_id)
             # event.assert_called_once_with('package_state_change', package=package,
             #                               prev_state='failing', new_state='ok')
-            self.assertItemsEqual([(x['id'],) for x in rnv_subtasks],
+            six.assertCountEqual(self, [(x['id'],) for x in rnv_subtasks],
                                   self.db.query(KojiTask.task_id))
 
     def test_refresh_latest_builds_already_present(self):
@@ -152,7 +153,7 @@ class BackendTest(DBTest):
         self.db.commit()
         with patch('koschei.backend.dispatch_event'):
             self.backend.refresh_latest_builds()
-            self.assertEquals(1, self.db.query(Build).count())
+            self.assertEqual(1, self.db.query(Build).count())
 
     def test_refresh_latest_builds_no_repo_id(self):
         self.secondary_koji.getTaskInfo = Mock(return_value=rnv_task)
@@ -172,7 +173,7 @@ class BackendTest(DBTest):
         self.db.commit()
         with patch('koschei.backend.dispatch_event'):
             self.backend.refresh_latest_builds()
-            self.assertEquals(1, self.db.query(Build).count())
+            self.assertEqual(1, self.db.query(Build).count())
 
     def test_refresh_latest_builds_skip_old(self):
         self.secondary_koji.getTaskInfo = Mock(return_value=rnv_task)
@@ -189,7 +190,7 @@ class BackendTest(DBTest):
         self.db.commit()
         with patch('koschei.backend.dispatch_event'):
             self.backend.refresh_latest_builds()
-            self.assertEquals(1, self.db.query(Build).count())
+            self.assertEqual(1, self.db.query(Build).count())
 
     def test_cancel_timed_out(self):
         self.prepare_packages(['rnv'])
@@ -199,7 +200,7 @@ class BackendTest(DBTest):
         self.koji_session.cancelTask = Mock(side_effect=koji.GenericError)
         self.backend.update_build_state(running_build, 'FREE')
         self.koji_session.cancelTask.assert_called_once_with(running_build.task_id)
-        self.assertEquals(0, self.db.query(Build).count())
+        self.assertEqual(0, self.db.query(Build).count())
 
     def test_cancel_requested(self):
         self.prepare_packages(['rnv'])
@@ -208,7 +209,7 @@ class BackendTest(DBTest):
         self.db.commit()
         self.backend.update_build_state(running_build, 'ASSIGNED')
         self.koji_session.cancelTask.assert_called_once_with(running_build.task_id)
-        self.assertEquals(0, self.db.query(Build).count())
+        self.assertEqual(0, self.db.query(Build).count())
 
     def test_refresh_packages(self):
         self.prepare_packages(['eclipse'])

--- a/test/common.py
+++ b/test/common.py
@@ -88,7 +88,7 @@ class DBTest(AbstractTest):
             with conn.cursor() as cur:
                 cur.execute("DROP DATABASE IF EXISTS {0}".format(dbname))
                 cur.execute("CREATE DATABASE {0}".format(dbname))
-                for option, value in DBTest.POSTGRES_OPTS.iteritems():
+                for option, value in DBTest.POSTGRES_OPTS.items():
                     cur.execute("ALTER DATABASE {0} SET {1} TO '{2}'".format(dbname,
                                                                              option,
                                                                              value))
@@ -119,7 +119,7 @@ class DBTest(AbstractTest):
         super(DBTest, self).setUp()
         tables = Base.metadata.tables
         conn = get_engine().connect()
-        for table in tables.values():
+        for table in list(tables.values()):
             conn.execute(table.delete())
             if hasattr(table.c, 'id'):
                 conn.execute("ALTER SEQUENCE {}_id_seq RESTART".format(table.name))

--- a/test/data_test.py
+++ b/test/data_test.py
@@ -18,6 +18,8 @@
 
 # pylint: disable=unbalanced-tuple-unpacking,blacklisted-name
 
+import six
+
 from test.common import DBTest
 from koschei.models import PackageGroup, PackageGroupRelation
 from koschei import data
@@ -35,7 +37,7 @@ class DataTest(DBTest):
         content = ['a1', 'a2', 'a3']
         data.set_group_content(self.db, group, content, append=False)
 
-        self.assertItemsEqual([a1.base_id, a2.base_id, a3.base_id],
+        six.assertCountEqual(self, [a1.base_id, a2.base_id, a3.base_id],
                               self.db.query(PackageGroupRelation.base_id)
                               .filter_by(group_id=group.id).all_flat())
 
@@ -50,6 +52,6 @@ class DataTest(DBTest):
         content = ['a1', 'a2', 'a3']
         data.set_group_content(self.db, group, content, append=True)
 
-        self.assertItemsEqual([bar.base_id, a1.base_id, a2.base_id, a3.base_id],
+        six.assertCountEqual(self, [bar.base_id, a1.base_id, a2.base_id, a3.base_id],
                               self.db.query(PackageGroupRelation.base_id)
                               .filter_by(group_id=group.id).all_flat())

--- a/test/frontend_test.py
+++ b/test/frontend_test.py
@@ -51,7 +51,7 @@ class FrontendTest(DBTest):
         reply = self.client.get('/')
         self.assertEqual(200, reply.status_code)
         self.assertEqual('text/html; charset=utf-8', reply.content_type)
-        normalized_data = ' '.join(reply.data.split())
+        normalized_data = ' '.join(reply.data.decode('utf-8').split())
         self.assertIn('<!DOCTYPE html>', normalized_data)
         self.assertIn('Packages from 1 to 0 from total 0', normalized_data)
         self.assertIn('Package summary', normalized_data)
@@ -68,7 +68,7 @@ class FrontendTest(DBTest):
     def test_documentation(self):
         reply = self.client.get('documentation')
         self.assertEqual(200, reply.status_code)
-        self.assertIn('How it works?', reply.data)
+        self.assertIn('How it works?', reply.data.decode('utf-8'))
 
     def test_login(self):
         reply = self.client.get('login')
@@ -82,7 +82,7 @@ class FrontendTest(DBTest):
         url = 'build/{0}/cancel'.format(build.id)
         reply = self.client.post(url, follow_redirects=True)
         self.assertEqual(200, reply.status_code)
-        self.assertIn('Cancelation request sent.', reply.data)
+        self.assertIn('Cancelation request sent.', reply.data.decode('utf-8'))
         self.db.expire(build)
         self.assertTrue(build.cancel_requested)
 
@@ -103,7 +103,7 @@ class FrontendTest(DBTest):
         url = 'build/{0}/cancel'.format(build.id)
         reply = self.client.post(url, follow_redirects=True)
         self.assertEqual(200, reply.status_code)
-        self.assertIn('Only running builds can be canceled.', reply.data)
+        self.assertIn('Only running builds can be canceled.', reply.data.decode('utf-8'))
         self.db.expire(build)
         self.assertFalse(build.cancel_requested)
 
@@ -116,7 +116,7 @@ class FrontendTest(DBTest):
         url = 'build/{0}/cancel'.format(build.id)
         reply = self.client.post(url, follow_redirects=True)
         self.assertEqual(200, reply.status_code)
-        self.assertIn('Build already has pending cancelation request.', reply.data)
+        self.assertIn('Build already has pending cancelation request.', reply.data.decode('utf-8'))
         self.db.expire(build)
         self.assertTrue(build.cancel_requested)
 
@@ -126,7 +126,7 @@ class FrontendTest(DBTest):
                                  data=dict(packages='SimplyHTML'),
                                  follow_redirects=True)
         self.assertEqual(200, reply.status_code)
-        self.assertIn('Packages don&#39;t exist: SimplyHTML', reply.data)
+        self.assertIn('Packages don&#39;t exist: SimplyHTML', reply.data.decode('utf-8'))
 
     @authenticate
     def test_add_package(self):
@@ -137,5 +137,5 @@ class FrontendTest(DBTest):
                                  data=dict(packages='xpp3'),
                                  follow_redirects=True)
         self.assertEqual(200, reply.status_code)
-        self.assertIn('Packages added: xpp3', reply.data)
+        self.assertIn('Packages added: xpp3', reply.data.decode('utf-8'))
         self.assertTrue(pkg.tracked)

--- a/test/scheduler_test.py
+++ b/test/scheduler_test.py
@@ -16,6 +16,8 @@
 #
 # Author: Michael Simacek <msimacek@redhat.com>
 
+import six
+
 from contextlib import contextmanager
 from datetime import timedelta, datetime
 
@@ -162,11 +164,11 @@ class SchedulerTest(DBTest):
         self.prepare_build('maven', False, resolved=False)
         query = self.get_scheduler().get_failed_build_priority_query()
         # fop has 1 failed build with no previous one, should it be prioritized?
-        # self.assertItemsEqual([(pkgs[0].id, 200), (pkgs[1].id, 200)],
+        # six.assertCountEqual(self, [(pkgs[0].id, 200), (pkgs[1].id, 200)],
         #                       query.all())
 
         # schedules rnv and firefox
-        self.assertItemsEqual([(pkgs[0].id, 200), (pkgs[6].id, 200)], query.all())
+        six.assertCountEqual(self, [(pkgs[0].id, 200), (pkgs[6].id, 200)], query.all())
 
     def test_coefficient(self):
         rnv, eclipse, fop = self.prepare_packages(['rnv', 'eclipse', 'fop'])
@@ -189,11 +191,11 @@ class SchedulerTest(DBTest):
         sched.get_time_priority_query = mock_prio
 
         priorities = sched.get_priorities()
-        self.assertEquals(eclipse.id, priorities[0][0])
+        self.assertEqual(eclipse.id, priorities[0][0])
         self.assertAlmostEqual(520, priorities[0][1], places=1)
-        self.assertEquals(rnv.id, priorities[1][0])
+        self.assertEqual(rnv.id, priorities[1][0])
         self.assertAlmostEqual(200, priorities[1][1], places=1)
-        self.assertEquals(fop.id, priorities[2][0])
+        self.assertEqual(fop.id, priorities[2][0])
         self.assertAlmostEqual(0, priorities[2][1], places=1)
         self.assertEqual(3, len(priorities))
 
@@ -204,13 +206,13 @@ class SchedulerTest(DBTest):
                           Column('pkg_id', Integer), Column('priority', Integer))
             conn = self.db.connection()
             table.create(bind=conn)
-            priorities = {name: prio for name, prio in kwargs.items() if '_' not in name}
-            builds = {name[:-len("_build")]: state for name, state in kwargs.items()
+            priorities = {name: prio for name, prio in list(kwargs.items()) if '_' not in name}
+            builds = {name[:-len("_build")]: state for name, state in list(kwargs.items())
                       if name.endswith('_build')}
-            states = {name[:-len('_state')]: state for name, state in kwargs.items()
+            states = {name[:-len('_state')]: state for name, state in list(kwargs.items())
                       if name.endswith('_state')}
             pkgs = []
-            for name in priorities.keys():
+            for name in list(priorities.keys()):
                 pkg = self.db.query(Package).filter_by(name=name).first()
                 if not pkg:
                     pkg = Package(name=name, tracked=states.get(name) != 'ignored',

--- a/test/watcher_test.py
+++ b/test/watcher_test.py
@@ -16,6 +16,8 @@
 #
 # Author: Michael Simacek <msimacek@redhat.com>
 
+import six
+
 from mock import Mock, patch
 
 from test.common import DBTest, KojiMock
@@ -97,6 +99,6 @@ class WatcherTest(DBTest):
             Watcher(db=self.db,
                     koji_sessions={'primary': koji_mock, 'secondary': Mock()}).main()
         self.assertEqual('ok', package.state_string)
-        self.assertEquals(460889, package.last_complete_build.repo_id)
-        self.assertItemsEqual([(x['id'],) for x in rnv_subtasks],
+        self.assertEqual(460889, package.last_complete_build.repo_id)
+        six.assertCountEqual(self, [(x['id'],) for x in rnv_subtasks],
                               self.db.query(KojiTask.task_id))


### PR DESCRIPTION
One test is unstable under Python 3.5 (sometimes passes, sometimes fails; it's some sqlalchemy thing I don't understand), but all other tests pass under both Python 2 and 3.

```
======================================================================
ERROR: test_coefficient (test.scheduler_test.SchedulerTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib64/python3.5/site-packages/sqlalchemy/util/_collections.py", line 210, in __getattr__
    return self._data[key]
KeyError: 'pkg_id'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/kojan/git/koschei/test/scheduler_test.py", line 193, in test_coefficient
    priorities = sched.get_priorities()
  File "/home/kojan/git/koschei/koschei/backend/services/scheduler.py", line 104, in get_priorities
    pkg_id = union_query.c.pkg_id
  File "/usr/lib64/python3.5/site-packages/sqlalchemy/util/_collections.py", line 212, in __getattr__
    raise AttributeError(key)
AttributeError: pkg_id

----------------------------------------------------------------------
Ran 91 tests in 3.773s

FAILED (errors=1)
```
