### PR TITLE
Switch to Koji 1.11

### DIFF
--- a/koschei.spec
+++ b/koschei.spec
@@ -19,7 +19,7 @@ BuildRequires:       python-nose
 BuildRequires:       python-vcrpy
 BuildRequires:       python-mock
 BuildRequires:       python-sqlalchemy
-BuildRequires:       koji
+BuildRequires:       koji >= 1.11
 BuildRequires:       python-hawkey
 BuildRequires:       python-librepo
 BuildRequires:       rpm-python

--- a/test/common.py
+++ b/test/common.py
@@ -55,50 +55,6 @@ my_vcr = vcr.VCR(
 )
 
 
-class RecordedKojiSession(object):
-    def __init__(self, server):
-        self._server = server
-        self.multicall = False
-        self._calls = []
-
-    def __getattr__(self, name):
-        def encode_args(args, kwargs):
-            kwargs['__starstar'] = True
-            return args + (kwargs,)
-
-        def method(*args, **kwargs):
-            if name != 'multiCall':
-                logging.debug("XML-RPC method {}: args={}, kwargs={}"
-                              .format(name, args, kwargs))
-            xml_request = dumps(encode_args(args, kwargs), name, allow_none=True)
-            reply = requests.post(self._server, xml_request,
-                                  headers={'Content-Type': 'text/xml'},
-                                  verify=False)
-            [[result], _] = loads(reply.content)
-            # logging.debug("XML-RPC result: {}".format(result))
-            return result
-
-        def method1(*args, **kwargs):
-            logging.debug("XML-RPC multicall method {}: args={}, kwargs={}"
-                          .format(name, args, kwargs))
-            kwargs['__starstar'] = True
-            self._calls.append({'methodName': name, 'params': encode_args(args, kwargs)})
-
-        if self.multicall:
-            return method1
-        return method
-
-    def multiCall(self):
-        assert self.multicall
-        self.multicall = False
-        try:
-            if not self._calls:
-                return []
-            return self.__getattr__('multiCall')(self._calls)
-        finally:
-            self._calls = []
-
-
 class AbstractTest(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):

--- a/test/koji_util_test.py
+++ b/test/koji_util_test.py
@@ -16,12 +16,15 @@
 #
 # Author: Mikolaj Izdebski <mizdebsk@redhat.com>
 
-from test.common import AbstractTest, RecordedKojiSession, my_vcr
+import koji
+
+from test.common import AbstractTest, my_vcr
 from koschei.backend import koji_util
+
 
 class KojiUtilTest(AbstractTest):
     def setUp(self):
-        self.session = RecordedKojiSession('https://koji.stg.fedoraproject.org/kojihub')
+        self.session = koji.ClientSession('https://koji.stg.fedoraproject.org/kojihub')
 
     @my_vcr.use_cassette('koji_load_all')
     def test_koji_load_all(self):


### PR DESCRIPTION
Koji 1.11 was just released. Its ClientSession is now backed by python-requests, so we can use vcr directly without custom RecordedKojiSession.