### PR TITLE
[copr] Use comps.xml

### DIFF
--- a/config.cfg.template
+++ b/config.cfg.template
@@ -267,6 +267,11 @@ config = {
             "dogpile.core.dogpile": {
                 "level": "INFO",
             },
+            "copr": {
+                # copr logs every exception as error, even though it's expected
+                # and handled
+                "level": "CRITICAL",
+            },
         },
         "handlers": {
             "stderr": {

--- a/koschei.spec
+++ b/koschei.spec
@@ -32,7 +32,7 @@ BuildRequires:       python-flask-wtf
 BuildRequires:       python-jinja2
 BuildRequires:       python-dogpile-cache
 BuildRequires:       python-six
-BuildRequires:       python-copr
+BuildRequires:       python-copr >= 1.75
 %endif
 
 %description
@@ -132,7 +132,7 @@ Requires:       %{name}-common = %{version}-%{release}
 Summary:        Koschei plugin for user rebuilds in Copr (backend part)
 Requires:       %{name}-backend = %{version}-%{release}
 Requires:       %{name}-copr-common = %{version}-%{release}
-Requires:       python-copr
+Requires:       python-copr >= 1.75
 
 %description backend-copr
 %{summary}.

--- a/koschei/models.py
+++ b/koschei/models.py
@@ -514,6 +514,9 @@ class CoprRebuildRequest(Base):
     ), nullable=False, server_default='new')
     error = Column(String)
 
+    def __str__(self):
+        return 'copr-request-{}'.format(self.id)
+
 
 class CoprResolutionChange(Base):
     request_id = Column(


### PR DESCRIPTION
Latest copr client added the ability to upload comps, so let's use it. Unfortunately it requires a file on disk, so we cannot pass just url pointing to koji, so it's a bit more code. On the other hand it should be faster, because we already have the comps file so it's just one request (APIv2 call accepted url, but was really slow as it was probably doing the download synchronously). Don't merge until python-copr-1.58 goes stable.