### PR TITLE
Rework priorities

### DIFF
--- a/alembic/versions/2cc3e44a68de_remove_current_priority.py
+++ b/alembic/versions/2cc3e44a68de_remove_current_priority.py
@@ -1,0 +1,24 @@
+"""
+Remove current_priority
+
+Create Date: 2017-03-09 13:38:59.186364
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '2cc3e44a68de'
+down_revision = '2f4667c1e18f'
+
+from alembic import op
+
+
+def upgrade():
+    op.execute("""
+        ALTER TABLE package DROP COLUMN current_priority;
+    """)
+
+
+def downgrade():
+    op.execute("""
+        ALTER TABLE package ADD COLUMN current_priority integer;
+    """)

--- a/alembic/versions/2f4667c1e18f_redo_priorities.py
+++ b/alembic/versions/2f4667c1e18f_redo_priorities.py
@@ -1,0 +1,31 @@
+"""
+Redo priorities
+
+Create Date: 2017-03-03 12:38:51.669916
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '2f4667c1e18f'
+down_revision = '2a0e9d5529c9'
+
+from alembic import op
+
+
+def upgrade():
+    op.execute("""
+        ALTER TABLE package ADD COLUMN build_priority integer;
+        ALTER TABLE package ADD COLUMN dependency_priority integer;
+        UPDATE package SET build_priority = 0, dependency_priority = 0;
+        ALTER TABLE package ALTER COLUMN build_priority SET DEFAULT 0;
+        ALTER TABLE package ALTER COLUMN build_priority SET NOT NULL;
+        ALTER TABLE package ALTER COLUMN dependency_priority SET DEFAULT 0;
+        ALTER TABLE package ALTER COLUMN dependency_priority SET NOT NULL;
+    """)
+
+
+def downgrade():
+    op.execute("""
+        ALTER TABLE package DROP COLUMN build_priority;
+        ALTER TABLE package DROP COLUMN dependency_priority;
+    """)

--- a/koschei/backend/services/resolver.py
+++ b/koschei/backend/services/resolver.py
@@ -335,9 +335,11 @@ class Resolver(Service):
             # get state after update
             new_state = package.msg_state_string
             # compute dependency priority
-            package.dependency_priority = sum(
-                update_weight / (change['distance'] or 8)
-                for change in pkg_result.changes
+            package.dependency_priority = int(
+                sum(
+                    update_weight / (change['distance'] or 8)
+                    for change in pkg_result.changes
+                )
             )
             if prev_state != new_state:
                 # queue for fedmsg sending after commit

--- a/koschei/backend/services/scheduler.py
+++ b/koschei/backend/services/scheduler.py
@@ -57,12 +57,7 @@ class Scheduler(Service):
                 self.log.info("Not scheduling: no package above threshold")
                 return
             package = self.db.query(Package).get(package_id)
-            if not package.collection.latest_repo_resolved:
-                self.log.info("Skipping {}: {} buildroot not resolved"
-                              .format(package, package.collection))
-                continue
 
-            # a package was chosen
             arches = self.db.query(KojiTask.arch)\
                 .filter_by(build_id=package.last_build_id)\
                 .all()

--- a/koschei/backend/services/scheduler.py
+++ b/koschei/backend/services/scheduler.py
@@ -18,12 +18,6 @@
 
 from __future__ import print_function, absolute_import, division
 
-import math
-import time
-
-from sqlalchemy import (func, union_all, extract, cast, Integer,
-                        literal_column, text, Column)
-
 from koschei import backend
 from koschei.config import get_config
 from koschei.backend import koji_util
@@ -31,129 +25,34 @@ from koschei.backend.service import Service
 from koschei.models import Package, Build, Collection, KojiTask
 
 
-def hours_since(what):
-    return extract('EPOCH', literal_column('clock_timestamp()') - what) / 3600
-
-
 class Scheduler(Service):
     koji_anonymous = False
 
     def __init__(self, session):
         super(Scheduler, self).__init__(session)
-        self.calculation_timestamp = 0
-
-    def get_dependency_priority_query(self):
-        update_weight = get_config('priorities.package_update')
-        cols = Column('pkg_id'), Column('priority')
-        query = text("""
-                SELECT package_id AS pkg_id, {w}/COALESCE(distance, 8) AS priority
-                FROM unapplied_change
-                WHERE prev_build_id IN (
-                    SELECT DISTINCT ON(package.id) build.id AS build_id
-                    FROM package JOIN build ON package.id = build.package_id
-                    WHERE deps_resolved
-                    ORDER BY package.id, build.id DESC
-                )
-                """.format(w=update_weight)).columns(*cols)
-        return self.db.query(*cols).from_statement(query)
-
-    def get_time_priority_query(self):
-        t0 = get_config('priorities.t0')
-        t1 = get_config('priorities.t1')
-        a = get_config('priorities.build_threshold') / (math.log10(t1) - math.log10(t0))
-        b = -a * math.log10(t0)
-        log_arg = func.greatest(0.000001, hours_since(func.max(Build.started)))
-        time_expr = func.greatest(a * func.log(log_arg) + b, -30)
-        return self.db.query(Build.package_id.label('pkg_id'),
-                             time_expr.label('priority'))\
-                      .group_by(Build.package_id)
-
-    def get_failed_build_priority_query(self):
-        rank = func.rank().over(partition_by=Package.id,
-                                order_by=Build.id.desc()).label('rank')
-        sub = self.db.query(Package.id.label('pkg_id'), Build.state,
-                            Build.deps_resolved, rank)\
-                     .outerjoin(Build,
-                                Package.id == Build.package_id)\
-                     .subquery()
-        failed_prio = get_config('priorities.failed_build_priority')
-        return self.db.query(
-            sub.c.pkg_id,
-            literal_column(str(failed_prio)).label('priority')
-        ).filter(
-            ((sub.c.rank == 1) & ((sub.c.state == 5) | (sub.c.deps_resolved == False))) |
-            ((sub.c.rank == 2) & (sub.c.state != 5))
-        ).group_by(sub.c.pkg_id).having(func.count(sub.c.pkg_id) == 2)
-
-    def get_priority_queries(self):
-        return [
-            self.get_dependency_priority_query(),
-            self.get_time_priority_query(),
-            self.get_failed_build_priority_query(),
-        ]
-
-    def get_incomplete_builds_query(self):
-        return self.db.query(Build.package_id).filter(Build.state == Build.RUNNING)
 
     def get_priorities(self):
-        incomplete_builds = self.get_incomplete_builds_query()
-        union_query = union_all(*self.get_priority_queries()).alias('un')
-        pkg_id = union_query.c.pkg_id
-        current_priority = cast(func.sum(union_query.c.priority),
-                                Integer).label('curr_priority')
-        priorities = self.db.query(pkg_id, current_priority)\
-                            .group_by(pkg_id).subquery()
-        computed_priority = func.coalesce(priorities.c.curr_priority *
-                                          Collection.priority_coefficient, 0)
-        priority_expr = (computed_priority + Package.manual_priority +
-                         Package.static_priority)
-        return self.db.query(Package.id, priority_expr, Package.current_priority)\
-                      .join(Package.collection)\
-                      .outerjoin(priorities, Package.id == priorities.c.pkg_id)\
-                      .filter((Package.resolved == True) |
-                              (Package.resolved == None))\
-                      .filter(Package.id.notin_(incomplete_builds.subquery()))\
-                      .filter(Package.blocked == False)\
-                      .filter(Package.tracked == True)\
-                      .order_by(priority_expr.desc())\
-                      .all()
-
-    def persist_priorities(self, prioritized):
-        if not prioritized:
-            return
-        threshold = get_config('priorities.priority_update_threshold', 100)
-        to_update = [{'package_id': package_id, 'priority': priority}
-                     for (package_id, priority, prev_prio) in prioritized
-                     if abs((priority or 0) - (prev_prio or 0)) > threshold]
-        if to_update:
-            self.lock_package_table()
-            self.db.execute(
-                text("""
-                    UPDATE package
-                    SET current_priority = :priority
-                    WHERE id = :package_id
-                """),
-                to_update,
-            )
-        self.db.commit()
-        self.calculation_timestamp = time.time()
-
-    def lock_package_table(self):
-        self.db.execute("LOCK TABLE package IN EXCLUSIVE MODE;")
+        priority_expr = Package.current_priority_expression(
+            collection=Collection,
+            last_build=Build,
+        )
+        return self.db.query(Package.id, priority_expr)\
+            .join(Package.collection)\
+            .join(Package.last_build)\
+            .filter(priority_expr != None)\
+            .order_by(priority_expr.desc())\
+            .all()
 
     def main(self):
-        prioritized = self.get_priorities()
-        self.db.rollback()  # no-op, ends the transaction
-        if (time.time() - self.calculation_timestamp >
-                get_config('priorities.calculation_interval')):
-            self.persist_priorities(prioritized)
-        incomplete_builds = self.get_incomplete_builds_query().count()
-        if incomplete_builds >= get_config('koji_config.max_builds'):
+        incomplete_builds_count = self.db.query(Build)\
+            .filter(Build.state == Build.RUNNING)\
+            .count()
+        if incomplete_builds_count >= get_config('koji_config.max_builds'):
             self.log.debug("Not scheduling: {} incomplete builds"
-                           .format(incomplete_builds))
+                           .format(incomplete_builds_count))
             return
 
-        for package_id, priority, _ in prioritized:
+        for package_id, priority in self.get_priorities():
             if priority < get_config('priorities.build_threshold'):
                 self.log.info("Not scheduling: no package above threshold")
                 return

--- a/koschei/models.py
+++ b/koschei/models.py
@@ -18,12 +18,17 @@
 
 from __future__ import print_function, absolute_import
 
-from sqlalchemy import (Column, Integer, String, Boolean, ForeignKey, DateTime,
-                        Index, Float, CheckConstraint, UniqueConstraint, Enum)
-from sqlalchemy.sql.expression import func, select, join, false, true
+import math
+
+from sqlalchemy import (
+    Column, Integer, String, Boolean, ForeignKey, DateTime, Index, Float,
+    CheckConstraint, UniqueConstraint, Enum,
+)
+from sqlalchemy.sql.expression import (
+    func, select, join, false, true, extract, case, null,
+)
 from sqlalchemy.orm import (relationship, column_property,
                             configure_mappers, deferred, composite)
-from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.dialects.postgresql import ARRAY
 
 from .config import get_config
@@ -126,6 +131,23 @@ def get_package_state(tracked, blocked, resolved, last_complete_build_state):
     return 'unknown'
 
 
+class TimePriority(object):
+    """
+    Container for lazy computation of static time priority inputs
+    """
+    def __getattr__(self, name):
+        assert name == 'inputs'
+        t0 = get_config('priorities.t0')
+        t1 = get_config('priorities.t1')
+        a = get_config('priorities.build_threshold') / (math.log10(t1) - math.log10(t0))
+        b = -a * math.log10(t0)
+        setattr(self, 'inputs', (a, b))
+        return self.inputs
+
+
+TIME_PRIORITY = TimePriority()
+
+
 class Package(Base):
     __table_args__ = (
         UniqueConstraint('base_id', 'collection_id',
@@ -139,8 +161,6 @@ class Package(Base):
                      nullable=False)
 
     name = Column(String, nullable=False, index=True)  # denormalized from base_package
-    static_priority = Column(Integer, nullable=False, server_default="0")
-    manual_priority = Column(Integer, nullable=False, server_default="0")
     collection_id = Column(Integer, ForeignKey(Collection.id, ondelete='CASCADE'),
                            nullable=False)
     collection = None  # backref, shut up pylint
@@ -169,11 +189,84 @@ class Package(Base):
                nullable=True)
     resolved = Column(Boolean)
 
+    # priority calculation input values
+    # priority set by (super)user, never reset by koschei
+    static_priority = Column(Integer, nullable=False, server_default='0')
+    # priority set by user, reset after a build is registered
+    manual_priority = Column(Integer, nullable=False, server_default='0')
+    # priority based on build - build started to fail, build failed to resolve,
+    # last build wasn't resolved and thus new build is necessary
+    build_priority = Column(Integer, nullable=False, server_default='0')
+    # priority based on dependency changes since last build
+    dependency_priority = Column(Integer, nullable=False, server_default='0')
+
     tracked = Column(Boolean, nullable=False, server_default=true())
     blocked = Column(Boolean, nullable=False, server_default=false())
 
     SKIPPED_NO_SRPM = 1
     scheduler_skip_reason = Column(Integer)
+
+    @classmethod
+    def current_priority_expression(cls, collection, last_build):
+        """
+        Return computed value for packages priority or None if package is not
+        schedulable.
+        """
+        # if last_build is concrete object, it may be None
+        # packages with no last build should have no priority
+        # (they cannot be scheduled)
+        if not last_build:
+            return null()
+
+        dynamic_priority = cls.dependency_priority + cls.build_priority
+
+        # compute time priority
+        seconds = extract('EPOCH', func.clock_timestamp() - last_build.started)
+        a, b = TIME_PRIORITY.inputs
+        # avoid zero/negative values, when time difference too small
+        log_arg = func.greatest(0.000001, seconds / 3600)
+        dynamic_priority += func.greatest(a * func.log(log_arg) + b, -30)
+
+        # dynamic priority is affected by coefficient
+        dynamic_priority *= collection.priority_coefficient
+
+        # manual and static priority are not affected by coefficient
+        current_priority = cls.manual_priority + cls.static_priority + dynamic_priority
+
+        return case(
+            [
+                # handle unschedulable packages
+                (
+                    # WHEN blocked OR untracked
+                    cls.blocked | ~cls.tracked |
+                    # OR has running build
+                    (cls.last_complete_build_id != cls.last_build_id) |
+                    # OR is unresolved
+                    (cls.resolved == False),
+                    # THEN return NULL
+                    None,
+                )
+            ],
+            # ELSE return the computed priority
+            else_=current_priority
+        )
+
+    @property
+    def skip_reasons(self):
+        reasons = []
+        if self.scheduler_skip_reason == Package.SKIPPED_NO_SRPM:
+            reasons.append("No suitable SRPM was found")
+        if not self.tracked:
+            reasons.append("Package is not tracked")
+        if self.blocked:
+            reasons.append("Package is blocked in koji")
+        if self.last_complete_build_id != self.last_build_id:
+            reasons.append("Package has a running build")
+        if self.resolved is False:
+            reasons.append("Package's dependencies are not reasolvable")
+        if not self.last_build:
+            reasons.append("Package has no known build")
+        return reasons
 
     @property
     def state_string(self):

--- a/koschei/models.py
+++ b/koschei/models.py
@@ -170,9 +170,6 @@ class Package(Base):
     # unresolved otherwise
     skip_resolution = Column(Boolean, nullable=False, server_default=false())
 
-    # cached value, populated by scheduler
-    current_priority = Column(Integer)
-
     # denormalized fields, updated by trigger on inser/update (no delete)
     last_complete_build_id = \
         Column(Integer, ForeignKey('build.id', use_alter=True,

--- a/koschei/models.py
+++ b/koschei/models.py
@@ -239,7 +239,11 @@ class Package(Base):
                     # OR has running build
                     (cls.last_complete_build_id != cls.last_build_id) |
                     # OR is unresolved
-                    (cls.resolved == False),
+                    (cls.resolved == False) |
+                    # OR the collection's buildroot is broken
+                    (collection.latest_repo_resolved == False) |
+                    # OR the collection's buildroot wasn't resolved yet
+                    (collection.latest_repo_resolved == None),
                     # THEN return NULL
                     None,
                 )
@@ -261,8 +265,14 @@ class Package(Base):
             reasons.append("Package has a running build")
         if self.resolved is False:
             reasons.append("Package's dependencies are not reasolvable")
-        if not self.last_build:
+        if not self.last_build_id:
             reasons.append("Package has no known build")
+        if self.collection.latest_repo_resolved is False:
+            reasons.append("Base buildroot for {} is not resolvable"
+                           .format(self.collection))
+        if self.collection.latest_repo_resolved is None:
+            reasons.append("Base buildroot for {} was not resolved yet"
+                           .format(self.collection))
         return reasons
 
     @property

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -105,7 +105,9 @@
             <td colspan="2"></td>
             {% endif %}
             <td>
-                {{ package.current_priority or ""}}
+                {% if package.current_priority is not none %}
+                {{ package.current_priority | int }}
+                {% endif %}
             </td>
             {% endif %}
             <td>

--- a/templates/package-detail.html
+++ b/templates/package-detail.html
@@ -67,21 +67,20 @@
         <td colspan="4">
             {{ package.state_icon }}
             {{ package.state_string }}
-            {% if package.scheduler_skip_reason %}
-            <br>
-            Package is not being scheduled
-            {% if package.scheduler_skip_reason == Package.SKIPPED_NO_SRPM %}
-            because no suitable SRPM was found
-            {% endif %}
-            {% endif %}
         </td>
     </tr>
     <tr>
         <th>Current priority</th>
         <td colspan="4">
-            {{ package.current_priority }}
+            {{ package.current_priority | int }}
         </td>
     </tr>
+    {% if package.current_priority is none %}
+    <tr>
+        <th>Currently not scheduling because:</th>
+        <td>{{ package.skip_reasons |join(',') }}</td>
+    </tr>
+    {% endif %}
     <tr>
         <th>Manual priority</th>
         <td colspan="4">

--- a/test/model_test.py
+++ b/test/model_test.py
@@ -16,11 +16,14 @@
 #
 # Author: Mikolaj Izdebski <mizdebsk@redhat.com>
 
-from koschei.models import Package, Collection
+from mock import patch
+from sqlalchemy import literal_column
+
+from koschei.models import Package, Collection, Build
 from test.common import DBTest
 
 
-class ModelTest(DBTest):
+class GroupTest(DBTest):
 
     def test_group_cardinality(self):
         group = self.prepare_group('xyzzy', content=['foo', 'bar', 'baz'])
@@ -85,3 +88,85 @@ class ModelTest(DBTest):
         self.db.add(pkg)
         self.db.commit()
         self.assertEqual(0, group.package_count)
+
+
+@patch('sqlalchemy.sql.expression.func.clock_timestamp',
+       return_value=literal_column("'2017-10-10 10:00:00'"))
+class PackagePriorityTest(DBTest):
+    def setUp(self):
+        super(PackagePriorityTest, self).setUp()
+        self.pkg = self.prepare_packages('rnv')[0]
+        self.pkg.resolved = True
+        self.build = self.prepare_build('rnv', state=True)
+        self.build.started = '2017-10-10 10:00:00'
+
+    def get_priority(self, pkg):
+        return self.db.query(
+            Package.current_priority_expression(
+                collection=pkg.collection,
+                last_build=pkg.last_build,
+            )
+        ).filter(Package.id == pkg.id).scalar()
+
+    def get_priority_join(self, pkg):
+        return self.db.query(
+            Package.current_priority_expression(
+                collection=Collection,
+                last_build=Build,
+            )
+        ).join(Package.collection)\
+            .join(Package.last_build)\
+            .filter(Package.id == pkg.id).scalar()
+
+    def assert_priority(self, expected, pkg=None):
+        pkg = pkg or self.pkg
+        self.db.commit()
+        self.assertAlmostEqual(expected, self.get_priority(pkg))
+        self.assertAlmostEqual(expected, self.get_priority_join(pkg))
+
+    def test_basic(self, _):
+        # time priority for just completed build, no other values
+        self.assert_priority(-30)
+
+    def test_coefficient(self, _):
+        self.pkg.manual_priority = 10
+        self.pkg.static_priority = 20
+        self.pkg.dependency_priority = 40
+        self.pkg.build_priority = 50
+        self.pkg.collection.priority_coefficient = 0.5
+        self.assert_priority(10 + 20 + 0.5 * (-30 + 40 + 50))
+
+    def test_time(self, _):
+        # 2 h difference
+        self.build.started = '2017-10-10 08:00:00'
+        self.assert_priority(-30)
+        # 10 h difference
+        self.build.started = '2017-10-10 00:00:00'
+        self.assert_priority(39.2446980024098)
+        # 1 day difference
+        self.build.started = '2017-10-9 00:00:00'
+        self.assert_priority(133.26248998925)
+        # 1 month difference
+        self.build.started = '2017-9-10 00:00:00'
+        self.assert_priority(368.863607520133)
+
+    def test_untracked(self, _):
+        self.pkg.tracked = False
+        self.assert_priority(None)
+
+    def test_blocked(self, _):
+        self.pkg.blocked = True
+        self.assert_priority(None)
+
+    def test_unresolved(self, _):
+        self.pkg.resolved = False
+        self.assert_priority(None)
+
+    def test_running_build(self, _):
+        self.prepare_build('rnv')
+        self.assert_priority(None)
+
+    def test_no_build(self, _):
+        pkg = self.prepare_packages('foo')[0]
+        pkg.resolved = True
+        self.assert_priority(None, pkg)

--- a/test/scheduler_test.py
+++ b/test/scheduler_test.py
@@ -16,18 +16,11 @@
 #
 # Author: Michael Simacek <msimacek@redhat.com>
 
-import six
-
-from contextlib import contextmanager
-from datetime import timedelta, datetime
-
 from mock import Mock, patch
-from sqlalchemy import Table, Column, Integer, MetaData
+from sqlalchemy import literal_column
 
 from test.common import DBTest
-from koschei.models import (
-    UnappliedChange, AppliedChange, Build, Package, Collection, KojiTask,
-)
+from koschei.models import Build, Package
 from koschei.backend.services.scheduler import Scheduler
 
 
@@ -37,220 +30,63 @@ class SchedulerTest(DBTest):
         sched = Scheduler(self.session)
         return sched
 
-    def prepare_depchanges(self):
-        build1 = self.prepare_build('rnv', True)
-        build2 = self.prepare_build('rnv', True)
-        build3 = self.prepare_build('eclipse', True)
-        chngs = []
-        # update, value 20
-        chngs.append(UnappliedChange(package_id=build1.package_id, dep_name='expat',
-                                     prev_version='2', curr_version='2',
-                                     prev_release='rc1', curr_release='rc2',
-                                     prev_build_id=build2.id,
-                                     distance=1))
-        # update - applied
-        chngs.append(AppliedChange(dep_name='expat',
-                                   prev_version='1', curr_version='2',
-                                   prev_release='1', curr_release='rc1',
-                                   distance=1, build_id=build2.id))
-        # downgrade, value 10
-        chngs.append(UnappliedChange(package_id=build1.package_id, dep_name='gcc',
-                                     prev_version='11', curr_version='9',
-                                     prev_release='19', curr_release='18',
-                                     prev_build_id=build2.id,
-                                     distance=2))
-        # appearance, value 5
-        chngs.append(UnappliedChange(package_id=build1.package_id, dep_name='python',
-                                     prev_version=None, curr_version='3.3',
-                                     prev_release=None, curr_release='11',
-                                     prev_build_id=build2.id,
-                                     distance=4))
-        # null distance, value 2
-        chngs.append(UnappliedChange(package_id=build1.package_id, dep_name='python-lxml',
-                                     prev_version=None, curr_version='3.3',
-                                     prev_release=None, curr_release='11',
-                                     prev_build_id=build2.id,
-                                     distance=None))
-        # not from current build
-        chngs.append(UnappliedChange(package_id=build1.package_id, dep_name='expat',
-                                     prev_version='2', curr_version='2',
-                                     prev_release='rc1', curr_release='rc2',
-                                     prev_build_id=build1.id,
-                                     distance=1))
-
-        # different package - eclipse, value 20
-        chngs.append(UnappliedChange(package_id=build3.package_id, dep_name='maven',
-                                     prev_version='2', curr_version='2',
-                                     prev_release='rc1', curr_release='rc2',
-                                     prev_build_id=build3.id,
-                                     distance=1))
-
-        for chng in chngs:
-            self.db.add(chng)
-        self.db.commit()
-        return build1.package, build3.package
-
-    def assert_priority_query(self, query):
-        columns = query.subquery().c
-        self.assertIn('pkg_id', columns)
-        self.assertIn('priority', columns)
-        self.assertEqual(2, len(columns))
-
-    def test_dependency_priority(self):
-        rnv, eclipse = self.prepare_depchanges()
-        query = self.get_scheduler().get_dependency_priority_query()
-        self.assert_priority_query(query)
-        res = query.all()
-        self.assertIn((rnv.id, 20), res)
-        self.assertIn((rnv.id, 10), res)
-        self.assertIn((rnv.id, 5), res)
-        self.assertIn((rnv.id, 2), res)
-        self.assertIn((eclipse.id, 20), res)
-        self.assertEqual(5, len(res))
-
-    # regression test for #100
-    def test_dependency_priority_unresolved_build_skipped(self):
-        rnv, eclipse = self.prepare_depchanges()
-        self.prepare_build('rnv', resolved=False)
-        query = self.get_scheduler().get_dependency_priority_query()
-        self.assert_priority_query(query)
-        res = query.all()
-        self.assertIn((rnv.id, 20), res)
-        self.assertIn((rnv.id, 10), res)
-        self.assertIn((rnv.id, 5), res)
-        self.assertIn((rnv.id, 2), res)
-        self.assertIn((eclipse.id, 20), res)
-        self.assertEqual(5, len(res))
-
-    def test_time_priority(self):
-        for days in [0, 2, 5, 7, 12]:
-            pkg = Package(name='p{}'.format(days), collection_id=self.collection.id)
+    def prepare_priorities(self, tablename='tmp', **kwargs):
+        priorities = {
+            name: prio for name, prio in list(kwargs.items()) if '_' not in name
+        }
+        builds = {name[:-len("_build")]: state for name, state in list(kwargs.items())
+                  if name.endswith('_build')}
+        states = {name[:-len('_state')]: state for name, state in list(kwargs.items())
+                  if name.endswith('_state')}
+        pkgs = []
+        for name in list(priorities.keys()):
+            pkg = Package(
+                name=name,
+                tracked=states.get(name) != 'ignored',
+                collection_id=self.collection.id,
+                # add 30 to offset time priority which will be -30
+                dependency_priority=priorities[name] + 30,
+            )
             self.ensure_base_package(pkg)
             self.db.add(pkg)
             self.db.flush()
-            build = Build(package_id=pkg.id,
-                          started=datetime.now() - timedelta(days, hours=1),
-                          version='1', release='1.fc25',
-                          task_id=days + 1)
-            self.db.add(build)
+            self.db.add(
+                Build(
+                    package_id=pkg.id,
+                    state=Build.COMPLETE,
+                    task_id=self.task_id_counter,
+                    version='1',
+                    release='1.fc25',
+                    started='2017-10-10 10:00:00',
+                    repo_id=1,
+                )
+            )
+            self.task_id_counter += 1
+            if states.get(name, True) is not None:
+                pkg.resolved = states.get(name) != 'unresolved'
+            pkgs.append((name, pkg))
+            if name in builds:
+                self.db.add(
+                    Build(
+                        package_id=pkg.id,
+                        state=builds[name],
+                        task_id=self.task_id_counter,
+                        version='1',
+                        release='1.fc25',
+                        started='2017-10-10 10:00:00',
+                        repo_id=1 if builds[name] != Build.RUNNING
+                        else None
+                    )
+                )
+                self.task_id_counter += 1
         self.db.commit()
-        query = self.get_scheduler().get_time_priority_query()
-        self.assert_priority_query(query)
-        res = sorted(query.all(), key=lambda x: x.priority)
-        self.assertEqual(5, len(res))
-        expected_prios = [-30.0, 161.339324401, 230.787748579,
-                          256.455946637, 297.675251883]
-        for item, exp in zip(res, expected_prios):
-            self.assertAlmostEqual(exp, item.priority, places=-1)
 
-    def test_failed_build_priority(self):
-        pkgs = self.prepare_packages('rnv', 'eclipse', 'fop', 'freemind', 'i3',
-                                     'maven', 'firefox')
-        self.prepare_build('rnv', True)
-        self.prepare_build('eclipse', False)
-        self.prepare_build('i3', True)
-        self.prepare_build('freemind', False)
-        self.prepare_build('maven', True)
-        self.prepare_build('firefox', True)
-        self.prepare_build('rnv', False)
-        self.prepare_build('eclipse', False)
-        self.prepare_build('fop', False)
-        self.prepare_build('freemind', False)
-        self.prepare_build('maven', False)
-        self.prepare_build('maven_resolved', False)
-        self.prepare_build('freemind', False)
-        self.prepare_build('firefox', True, resolved=False)
-        self.prepare_build('maven', False, resolved=False)
-        query = self.get_scheduler().get_failed_build_priority_query()
-        # fop has 1 failed build with no previous one, should it be prioritized?
-        # six.assertCountEqual(self, [(pkgs[0].id, 200), (pkgs[1].id, 200)],
-        #                       query.all())
-
-        # schedules rnv and firefox
-        six.assertCountEqual(self, [(pkgs[0].id, 200), (pkgs[6].id, 200)], query.all())
-
-    def test_coefficient(self):
-        rnv, eclipse, fop = self.prepare_packages('rnv', 'eclipse', 'fop')
-        eclipse_coll = Collection(name='eclipse', display_name='eclipse',
-                                  build_tag='foo', dest_tag='foo', target='foo',
-                                  priority_coefficient=0.1)
-        self.db.add(eclipse_coll)
-        self.db.flush()
-        eclipse.collection_id = eclipse_coll.id
-        self.prepare_build('rnv', True)
-        self.prepare_build('rnv', False)
-        self.prepare_build('eclipse', True)
-        self.prepare_build('eclipse', False)
-        eclipse.manual_priority = 500
-        sched = self.get_scheduler()
-
-        def mock_prio():
-            return self.db.query(Package.id, Package.manual_priority)\
-                .filter_by(id=12309)
-        sched.get_time_priority_query = mock_prio
-
-        priorities = sched.get_priorities()
-        self.assertEqual(eclipse.id, priorities[0][0])
-        self.assertAlmostEqual(520, priorities[0][1], places=1)
-        self.assertEqual(rnv.id, priorities[1][0])
-        self.assertAlmostEqual(200, priorities[1][1], places=1)
-        self.assertEqual(fop.id, priorities[2][0])
-        self.assertAlmostEqual(0, priorities[2][1], places=1)
-        self.assertEqual(3, len(priorities))
-
-    @contextmanager
-    def prio_table(self, tablename='tmp', **kwargs):
-        try:
-            table = Table(tablename, MetaData(),
-                          Column('pkg_id', Integer), Column('priority', Integer))
-            conn = self.db.connection()
-            table.create(bind=conn)
-            priorities = {name: prio for name, prio in list(kwargs.items()) if '_' not in name}
-            builds = {name[:-len("_build")]: state for name, state in list(kwargs.items())
-                      if name.endswith('_build')}
-            states = {name[:-len('_state')]: state for name, state in list(kwargs.items())
-                      if name.endswith('_state')}
-            pkgs = []
-            for name in list(priorities.keys()):
-                pkg = self.db.query(Package).filter_by(name=name).first()
-                if not pkg:
-                    pkg = Package(name=name, tracked=states.get(name) != 'ignored',
-                                  collection_id=self.collection.id)
-                    self.ensure_base_package(pkg)
-                    self.db.add(pkg)
-                    self.db.flush()
-                    if states.get(name, True) is not None:
-                        pkg.resolved = states.get(name) != 'unresolved'
-                pkgs.append((name, pkg))
-                if name in builds:
-                    self.db.add(Build(package_id=pkg.id, state=builds[name],
-                                      task_id=self.task_id_counter,
-                                      version='1', release='1.fc25',
-                                      started=datetime.fromtimestamp(123),
-                                      repo_id=1 if builds[name] != Build.RUNNING
-                                      else None))
-                    self.task_id_counter += 1
-            # pylint:disable = no-value-for-parameter
-            conn.execute(table.insert(), [{'pkg_id': pkg.id, 'priority': priorities[name]}
-                                          for name, pkg in pkgs])
-            self.db.commit()
-            yield table
-        finally:
-            self.db.rollback()
-            conn = self.db.connection()
-            table.drop(bind=conn, checkfirst=True)
-            self.db.commit()
-
-    def assert_scheduled(self, tables, scheduled, koji_load=0.3):
+    def assert_scheduled(self, scheduled, koji_load=0.3):
         with patch('koschei.backend.koji_util.get_koji_load',
                    Mock(return_value=koji_load)):
             sched = self.get_scheduler()
-
-            def get_prio_q():
-                return [self.db.query(t.c.pkg_id.label('pkg_id'),
-                                      t.c.priority.label('priority'))
-                        for t in tables]
-            with patch.object(sched, 'get_priority_queries', get_prio_q):
+            with patch('sqlalchemy.sql.expression.func.clock_timestamp',
+                       return_value=literal_column("'2017-10-10 10:00:00'")):
                 with patch('koschei.backend.submit_build') as submit_mock:
                     sched.main()
                     if scheduled:
@@ -260,76 +96,65 @@ class SchedulerTest(DBTest):
                         self.assertFalse(submit_mock.called)
 
     def test_low(self):
-        with self.prio_table(rnv=10) as table:
-            self.assert_scheduled([table], scheduled=None)
+        self.prepare_priorities(rnv=10)
+        self.assert_scheduled(None)
 
     def test_submit1(self):
-        with self.prio_table(rnv=256) as table:
-            self.assert_scheduled([table], scheduled='rnv')
+        self.prepare_priorities(rnv=256)
+        self.assert_scheduled('rnv')
 
     def test_submit_no_resolution(self):
-        with self.prio_table(rnv=256, rnv_state=None) as table:
-            self.assert_scheduled([table], scheduled='rnv')
+        self.prepare_priorities(rnv=256, rnv_state=None)
+        self.assert_scheduled('rnv')
 
     def test_load(self):
-        with self.prio_table(rnv=30000) as table:
-            self.assert_scheduled([table], koji_load=0.7, scheduled=None)
+        self.prepare_priorities(rnv=30000)
+        self.assert_scheduled(None, koji_load=0.7)
 
     def test_max_builds(self):
-        with self.prio_table(rnv=30, rnv_build=Build.RUNNING,
-                             eclipse=300, eclipse_build=Build.RUNNING,
-                             expat=400) as table:
-            self.assert_scheduled([table], scheduled=None)
+        self.prepare_priorities(rnv=30, rnv_build=Build.RUNNING,
+                                eclipse=300, eclipse_build=Build.RUNNING,
+                                expat=400)
+        self.assert_scheduled(None)
 
     def test_running1(self):
-        with self.prio_table(rnv=30000, rnv_build=Build.RUNNING) as table:
-            self.assert_scheduled([table], scheduled=None)
+        self.prepare_priorities(rnv=30000, rnv_build=Build.RUNNING)
+        self.assert_scheduled(None)
 
     def test_running2(self):
-        with self.prio_table(eclipse=100, rnv=300, rnv_build=Build.RUNNING) as table:
-            self.assert_scheduled([table], scheduled=None)
+        self.prepare_priorities(eclipse=100, rnv=300, rnv_build=Build.RUNNING)
+        self.assert_scheduled(None)
 
     def test_running3(self):
-        with self.prio_table(eclipse=280, rnv=300, rnv_build=Build.RUNNING) as table:
-            self.assert_scheduled([table], scheduled='eclipse')
+        self.prepare_priorities(eclipse=280, rnv=300, rnv_build=Build.RUNNING)
+        self.assert_scheduled('eclipse')
 
     def test_multiple(self):
-        with self.prio_table(eclipse=280, rnv=300) as table:
-            self.assert_scheduled([table], scheduled='rnv')
+        self.prepare_priorities(eclipse=280, rnv=300)
+        self.assert_scheduled('rnv')
 
     def test_builds(self):
-        with self.prio_table(eclipse=100, rnv=300, rnv_build=Build.COMPLETE,
-                             eclipse_build=Build.RUNNING) as table:
-            self.assert_scheduled([table], scheduled='rnv')
+        self.prepare_priorities(eclipse=100, rnv=300, rnv_build=Build.COMPLETE,
+                                eclipse_build=Build.RUNNING)
+        self.assert_scheduled('rnv')
 
     def test_state1(self):
-        with self.prio_table(rnv=300, rnv_state='unresolved') as table:
-            self.assert_scheduled([table], scheduled=None)
+        self.prepare_priorities(rnv=300, rnv_state='unresolved')
+        self.assert_scheduled(None)
 
     def test_state2(self):
-        with self.prio_table(rnv=300, rnv_state='ignored') as table:
-            self.assert_scheduled([table], scheduled=None)
-
-    def test_union1(self):
-        with self.prio_table(tablename='tmp1', rnv=100) as table1:
-            with self.prio_table(tablename='tmp2', eclipse=280, rnv=200) as table2:
-                self.assert_scheduled([table1, table2], scheduled='rnv')
-
-    def test_union2(self):
-        with self.prio_table(tablename='tmp1', rnv=100) as table1:
-            with self.prio_table(tablename='tmp2', eclipse=300, rnv=200) as table2:
-                with self.prio_table(tablename='tmp3', eclipse=201, rnv=200) as table3:
-                    self.assert_scheduled([table1, table2, table3], scheduled='eclipse')
+        self.prepare_priorities(rnv=300, rnv_state='ignored')
+        self.assert_scheduled(None)
 
     def test_broken_buildroot(self):
         self.collection.latest_repo_resolved = False
-        with self.prio_table(rnv=256, rnv_state=None) as table:
-            self.assert_scheduled([table], scheduled=None)
+        self.prepare_priorities(rnv=256, rnv_state=None)
+        self.assert_scheduled(None)
 
     def test_buildroot_not_yet_resolved(self):
         self.collection.latest_repo_resolved = None
-        with self.prio_table(rnv=256, rnv_state=None) as table:
-            self.assert_scheduled([table], scheduled=None)
+        self.prepare_priorities(rnv=256, rnv_state=None)
+        self.assert_scheduled(None)
 
     def test_load_not_determined_when_no_schedulable_packages(self):
         with patch('koschei.backend.koji_util.get_koji_load') as load_mock:


### PR DESCRIPTION
Rework priority calculation such that every component can see the same accurate priority values. Most notably scheduler will see exactly the same thing as is displayed in the frontend.
How:
- there is no current_priority field, priority is computed dynamically
- dependency priority is stored directly on package (dependency_priority column) and is populated by resolver when resolving new repo. Race condition described in #100 should be prevented by locking package before persisting and comparing last build id from the time the resolution was done with the current value
- failed build priority is stored directly on package (build_priority column), set by backend when the failed build arrives, or by resolver when a build fails to resolve
- priority is computed in the package model using SQL query expression dependent on collection and last build
- scheduler no longer contains any logic for prioritization. It only uses the same priority query from model and does koji-related work
- package table no longer needs periodic full rewrites for storing current priority. On the other hand it requires writing the dependency priority, but that shouldn't change so rapidly