### PR TITLE
Add statistics page [PoC]

### DIFF
--- a/koschei/backend/services/polling.py
+++ b/koschei/backend/services/polling.py
@@ -23,7 +23,7 @@ import koji
 from sqlalchemy.orm.exc import ObjectDeletedError, StaleDataError
 
 from koschei import plugin, backend
-from koschei.models import Build, ResourceConsumptionStats
+from koschei.models import Build, ResourceConsumptionStats, ScalarStats
 from koschei.backend.service import Service
 from koschei.backend.koji_util import itercall
 
@@ -66,6 +66,6 @@ class Polling(Service):
         backend.refresh_latest_builds(self.session)
         self.db.commit()
         self.log.info('Refreshing statistics...')
-        self.db.refresh_mv(ResourceConsumptionStats)
+        self.db.refresh_mv(ResourceConsumptionStats, ScalarStats)
         self.db.commit()
         self.log.info('Polling finished')

--- a/koschei/backend/services/polling.py
+++ b/koschei/backend/services/polling.py
@@ -23,7 +23,7 @@ import koji
 from sqlalchemy.orm.exc import ObjectDeletedError, StaleDataError
 
 from koschei import plugin, backend
-from koschei.models import Build
+from koschei.models import Build, ResourceConsumptionStats
 from koschei.backend.service import Service
 from koschei.backend.koji_util import itercall
 
@@ -64,5 +64,8 @@ class Polling(Service):
         self.db.close()
         self.log.info('Polling latest real builds...')
         backend.refresh_latest_builds(self.session)
+        self.db.commit()
+        self.log.info('Refreshing statistics...')
+        self.db.refresh_mv(ResourceConsumptionStats)
         self.db.commit()
         self.log.info('Polling finished')

--- a/koschei/backend/services/polling.py
+++ b/koschei/backend/services/polling.py
@@ -66,6 +66,6 @@ class Polling(Service):
         backend.refresh_latest_builds(self.session)
         self.db.commit()
         self.log.info('Refreshing statistics...')
-        self.db.refresh_mv(ResourceConsumptionStats, ScalarStats)
+        self.db.refresh_materialized_view(ResourceConsumptionStats, ScalarStats)
         self.db.commit()
         self.log.info('Polling finished')

--- a/koschei/db.py
+++ b/koschei/db.py
@@ -339,6 +339,7 @@ class MaterializedView(Base):
                 index.create(db)
         else:
             cls._table.create(db)
+            cls.refresh(db)
 
     @classmethod
     def refresh(cls, db):

--- a/koschei/db.py
+++ b/koschei/db.py
@@ -326,7 +326,7 @@ class MaterializedView(Base):
 
     @classmethod
     def create(cls, db):
-        view_sql = cls.view.compile()
+        view_sql = cls.view.compile(dialect=sqlalchemy.dialects.postgresql.dialect())
         ddl_sql = 'CREATE MATERIALIZED VIEW "{0}" AS {1}'.format(cls.__tablename__, view_sql)
         db.execute(ddl_sql)
         for index in cls._table.indexes:

--- a/koschei/db.py
+++ b/koschei/db.py
@@ -129,7 +129,10 @@ class KoscheiDbSession(sqlalchemy.orm.session.Session):
         finally:
             self.expire_on_commit = expire_on_commit
 
-    def refresh_mv(self, *args):
+    def refresh_materialized_view(self, *args):
+        """
+        Refresh materialized view(s) passed as args.
+        """
         self.flush()
         for mv in args:
             mv.refresh(self)

--- a/koschei/db.py
+++ b/koschei/db.py
@@ -318,11 +318,12 @@ class MaterializedView(Base):
 
     @declared_attr
     def __table__(cls):
-        cls._table = Table(cls.__tablename__, sqlalchemy.MetaData())
-        for column in cls.view.c:
-            cls._table.append_column(Column(column.name, column.type))
-        cls._table.append_constraint(PrimaryKeyConstraint(*[column.name for column in cls.view.c]))
-        listen(Base.metadata, 'after_create', lambda _, conn, **kwargs: cls.create(conn))
+        if cls._table is None:
+            cls._table = Table(cls.__tablename__, sqlalchemy.MetaData())
+            for column in cls.view.c:
+                cls._table.append_column(Column(column.name, column.type))
+            cls._table.append_constraint(PrimaryKeyConstraint(*[column.name for column in cls.view.c]))
+            listen(Base.metadata, 'after_create', lambda _, conn, **kwargs: cls.create(conn))
         return cls._table
 
     @declared_attr

--- a/koschei/frontend/views.py
+++ b/koschei/frontend/views.py
@@ -931,7 +931,7 @@ def statistics():
     scalar_stats = db.query(ScalarStats).one()
     resource_query = db.query(ResourceConsumptionStats)\
         .order_by(ResourceConsumptionStats.time.desc())\
-        .limit(1000).paginate(20)
+        .paginate(20)
     return render_template("stats.html", now=now, stats=scalar_stats,
                            packages=resource_query.items,
                            page=resource_query)

--- a/koschei/frontend/views.py
+++ b/koschei/frontend/views.py
@@ -927,7 +927,7 @@ def affected_by(dep_name):
 @app.route('/stats')
 @stats_tab.master
 def statistics():
-    now = db.query(func.now().label('now')).one().now
+    now = db.query(func.now()).scalar()
     scalar_stats = db.query(ScalarStats).one()
     resource_query = db.query(ResourceConsumptionStats)\
         .order_by(ResourceConsumptionStats.time.desc())\

--- a/koschei/frontend/views.py
+++ b/koschei/frontend/views.py
@@ -39,7 +39,7 @@ from koschei.frontend import app, db, frontend_config, auth, session, forms, Tab
 from koschei.models import (
     Package, Build, PackageGroup, PackageGroupRelation, AdminNotice,
     BuildrootProblem, BasePackage, GroupACL, Collection, CollectionGroup,
-    AppliedChange, UnappliedChange, ResolutionChange,
+    AppliedChange, UnappliedChange, ResolutionChange, ResourceConsumptionStats,
     get_package_state,
 )
 
@@ -425,6 +425,7 @@ package_tab = Tab('Packages', 10)
 group_tab = Tab('Groups', 20)
 add_packages_tab = Tab('Add packages', 30)
 my_packages_tab = Tab('My packages', 50, requires_user=True)
+stats_tab = Tab('Statistics', 100)
 documentation_tab = Tab('Documentation', 1000)
 
 
@@ -920,3 +921,12 @@ def affected_by(dep_name):
     return render_template("affected-by.html", package_state=package_state,
                            dep_name=dep_name, evr1=evr1, evr2=evr2,
                            collection=collection, failed=failed)
+
+
+@app.route('/stats')
+@stats_tab.master
+def statistics():
+    resource_query = db.query(ResourceConsumptionStats)\
+        .order_by(ResourceConsumptionStats.time.desc())\
+        .limit(1000).paginate(20)
+    return render_template("stats.html", packages=resource_query.items, page=resource_query)

--- a/koschei/frontend/views.py
+++ b/koschei/frontend/views.py
@@ -927,10 +927,11 @@ def affected_by(dep_name):
 @app.route('/stats')
 @stats_tab.master
 def statistics():
+    now = db.query(func.now().label('now')).one().now
     scalar_stats = db.query(ScalarStats).one()
     resource_query = db.query(ResourceConsumptionStats)\
         .order_by(ResourceConsumptionStats.time.desc())\
         .limit(1000).paginate(20)
-    return render_template("stats.html", stats=scalar_stats,
+    return render_template("stats.html", now=now, stats=scalar_stats,
                            packages=resource_query.items,
                            page=resource_query)

--- a/koschei/frontend/views.py
+++ b/koschei/frontend/views.py
@@ -40,6 +40,7 @@ from koschei.models import (
     Package, Build, PackageGroup, PackageGroupRelation, AdminNotice,
     BuildrootProblem, BasePackage, GroupACL, Collection, CollectionGroup,
     AppliedChange, UnappliedChange, ResolutionChange, ResourceConsumptionStats,
+    ScalarStats,
     get_package_state,
 )
 
@@ -926,7 +927,10 @@ def affected_by(dep_name):
 @app.route('/stats')
 @stats_tab.master
 def statistics():
+    scalar_stats = db.query(ScalarStats).one()
     resource_query = db.query(ResourceConsumptionStats)\
         .order_by(ResourceConsumptionStats.time.desc())\
         .limit(1000).paginate(20)
-    return render_template("stats.html", packages=resource_query.items, page=resource_query)
+    return render_template("stats.html", stats=scalar_stats,
+                           packages=resource_query.items,
+                           page=resource_query)

--- a/koschei/models.py
+++ b/koschei/models.py
@@ -696,6 +696,7 @@ def count_query(type):
 # TODO migrations
 class ScalarStats(MaterializedView):
     view = select((
+        func.now().label('refresh_time'),
         count_query(Package).label('packages'),
         count_query(Package).where(Package.tracked).label('tracked_packages'),
         count_query(Package).where(Package.blocked).label('blocked_packages'),

--- a/koschei/models.py
+++ b/koschei/models.py
@@ -690,6 +690,21 @@ class CoprRebuild(Base):
         )
 
 
+def count_query(type):
+    return select((func.count(type.id),)).select_from(type)
+
+# TODO migrations
+class ScalarStats(MaterializedView):
+    view = select((
+        count_query(Package).label('packages'),
+        count_query(Package).where(Package.tracked).label('tracked_packages'),
+        count_query(Package).where(Package.blocked).label('blocked_packages'),
+        count_query(Build).label('builds'),
+        count_query(Build).where(Build.real).label('real_builds'),
+        count_query(Build).where(~Build.real).label('scratch_builds'),
+    ))
+
+
 # TODO migrations
 class ResourceConsumptionStats(MaterializedView):
     view = select((Package.name,

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -4,7 +4,7 @@
 {% block content %}
 <div class="pageHeader">Koschei in numbers</div>
 <table class="details">
-    <tr><th>Stats update time</th><td>{{ stats.refresh_time }} ({{ now - stats.refresh_time }} ago)</td></tr>
+    <tr><th>Stats update time</th><td>{{ stats.refresh_time }}</td></tr>
     <tr><th>All packages</th><td>{{ stats.packages }}</td></tr>
     <tr><th>Tracked packages</th><td>{{ stats.tracked_packages }}</td></tr>
     <tr><th>Untracked packages</th><td>{{ stats.packages - stats.tracked_packages }}</td></tr>

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -2,8 +2,20 @@
 {% import "macros.html" as macros %}
 {% block title %}Koschei - statistics{% endblock %}
 {% block content %}
-{{ macros.pagination_row(page, 'Packages') }}
+<div class="pageHeader">Koschei in numbers</div>
+<table class="details">
+    <tr><th>All packages</th><td>{{ stats.packages }}</td></tr>
+    <tr><th>Tracked packages</th><td>{{ stats.tracked_packages }}</td></tr>
+    <tr><th>Untracked packages</th><td>{{ stats.packages - stats.tracked_packages }}</td></tr>
+    <tr><th>Blocked packages</th><td>{{ stats.blocked_packages }}</td></tr>
+    <tr><th>Active packages</th><td>{{ stats.packages - stats.blocked_packages }}</td></tr>
+    <tr><th>All builds (real and scratch)</th><td>{{ stats.builds }}</td></tr>
+    <tr><th>Real builds</th><td>{{ stats.real_builds }}</td></tr>
+    <tr><th>Scratch builds</th><td>{{ stats.scratch_builds }}</td></tr>
+</table>
+
 <div class="pageHeader">Packages that consume most resources</div>
+{{ macros.pagination_row(page, 'Packages') }}
 <table class="data-list">
     <tr class="list-header">
         <th>Package</th>

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -4,6 +4,7 @@
 {% block content %}
 <div class="pageHeader">Koschei in numbers</div>
 <table class="details">
+    <tr><th>Stats update time</th><td>{{ stats.refresh_time }} ({{ now - stats.refresh_time }} ago)</td></tr>
     <tr><th>All packages</th><td>{{ stats.packages }}</td></tr>
     <tr><th>Tracked packages</th><td>{{ stats.tracked_packages }}</td></tr>
     <tr><th>Untracked packages</th><td>{{ stats.packages - stats.tracked_packages }}</td></tr>

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+{% import "macros.html" as macros %}
+{% block title %}Koschei - statistics{% endblock %}
+{% block content %}
+{{ macros.pagination_row(page, 'Packages') }}
+<div class="pageHeader">Packages that consume most resources</div>
+<table class="data-list">
+    <tr class="list-header">
+        <th>Package</th>
+        <th>Arch</th>
+        <th>Time usage</th>
+        <th>Time percentage</th>
+    </tr>
+    {% for package in packages %}
+    <tr>
+        <td>
+            <a href="{{ url_for('package_detail', name=package.name)}}">
+                {{ package.name }}
+            </a>
+        </td>
+        <td>{{ package.arch }}</td>
+        <td>{{ package.time }}</td>
+        <td>{{ package.time_percentage }}</td>
+    </tr>
+    {% endfor %}
+</table>
+{{ macros.pagination_row(page, 'Packages') }}
+{% endblock %}

--- a/test/model_test.py
+++ b/test/model_test.py
@@ -208,7 +208,7 @@ class StatsTest(DBTest):
         # Before refresh MV should be empty
         self.assertEqual(0, self.db.query(ResourceConsumptionStats).count())
         # After refresh it should contain some entries
-        self.db.refresh_mv(ResourceConsumptionStats)
+        self.db.refresh_materialized_view(ResourceConsumptionStats)
         self.assertEqual(2, self.db.query(ResourceConsumptionStats).count())
         # Now add more data
         self.add_task(rnv, 'x86_64', 1000, 1100)
@@ -218,7 +218,7 @@ class StatsTest(DBTest):
         self.add_task(self.prepare_build('junit'), 'noarch', 24, 42)
         # Until it's refreshed again, MV should still contain only 2 rows
         self.assertEqual(2, self.db.query(ResourceConsumptionStats).count())
-        self.db.refresh_mv(ResourceConsumptionStats)
+        self.db.refresh_materialized_view(ResourceConsumptionStats)
         self.assertEqual(4, self.db.query(ResourceConsumptionStats).count())
         stats = self.db.query(ResourceConsumptionStats).order_by(ResourceConsumptionStats.time).all()
         self.assertEqual('junit', stats[0].name)
@@ -235,13 +235,13 @@ class StatsTest(DBTest):
         self.assertEqual(timedelta(0, 333 + 100 + 500), stats[3].time)
 
     def test_package_counts(self):
-        self.db.refresh_mv(ScalarStats)
+        self.db.refresh_materialized_view(ScalarStats)
         stats = self.db.query(ScalarStats).one()
         self.assertEqual(0, stats.packages)
         self.prepare_packages('rnv')[0].tracked = False
         self.prepare_packages('junit')[0].blocked = True
         self.prepare_packages('xpp3')
-        self.db.refresh_mv(ScalarStats)
+        self.db.refresh_materialized_view(ScalarStats)
         stats = self.db.query(ScalarStats).one()
         self.assertEqual(3, stats.packages)
         self.assertEqual(2, stats.tracked_packages)
@@ -254,7 +254,7 @@ class StatsTest(DBTest):
             self.prepare_build('rnv', False)
         for i in range(0, 4):
             self.prepare_build('rnv', None)
-        self.db.refresh_mv(ScalarStats)
+        self.db.refresh_materialized_view(ScalarStats)
         stats = self.db.query(ScalarStats).one()
         self.assertEqual(16, stats.builds)
         self.assertEqual(7, stats.real_builds)


### PR DESCRIPTION
This is proof-of-concept of statistics page (#46) and example of usage of materialized views with SQLAlchemy.

This code makes use of PostgreSQL materialized views, do not merge it until Fedora infra production database is updated to PostgreSQL 9.3 or newer.