### PR TITLE
Optimize packages API endpoint

### DIFF
--- a/koschei/db.py
+++ b/koschei/db.py
@@ -32,7 +32,7 @@ from sqlalchemy.orm import sessionmaker, CompositeProperty
 from sqlalchemy.engine.url import URL
 from sqlalchemy.event import listen
 from sqlalchemy.types import TypeDecorator
-from sqlalchemy.sql import func
+from sqlalchemy.sql import func, column
 from sqlalchemy.dialects.postgresql import BYTEA
 
 from . import util
@@ -81,6 +81,13 @@ class Query(sqlalchemy.orm.Query):
 
     def all_flat(self, ctor=list):
         return ctor(x for [x] in self)
+
+    def as_record(self):
+        """
+        Casts a select query to postgres record type
+        """
+        subq = self.subquery()
+        return self.session.query(column(subq.name)).select_from(subq).as_scalar()
 
 
 class KoscheiDbSession(sqlalchemy.orm.session.Session):

--- a/koschei/frontend/api.py
+++ b/koschei/frontend/api.py
@@ -16,48 +16,50 @@
 #
 # Author: Mikolaj Izdebski <mizdebsk@redhat.com>
 
-from flask import jsonify, request
-from sqlalchemy.orm import contains_eager
-from koschei.util import merge_sorted
+import json
+
+from flask import request, Response
 from koschei.frontend import app, db
-from koschei.models import Package, Collection, Build
-
-
-def build_to_json(build):
-    if build:
-        return {'task_id': build.task_id}
-
-
-def package_to_json(package):
-    if package:
-        return {'name': package.name,
-                'collection': package.collection.name,
-                'state': package.state_string,
-                'last_complete_build': build_to_json(package.last_complete_build)}
-
-
-def packages_to_json(packages):
-    return [package_to_json(p) for p in packages]
+from koschei.models import Package, Collection, Build, get_package_state
 
 
 @app.route('/api/v1/packages')
 def list_packages():
-    def run_query(query):
-        query = query.join(Collection, Collection.id == Package.collection_id)\
-            .options(contains_eager(Package.collection))
-        if 'name' in request.args:
-            query = query.filter(Package.name.in_(request.args.getlist('name')))
-        if 'collection' in request.args:
-            query = query.filter(Collection.name.in_(request.args.getlist('collection')))
-        return query.order_by(Package.name).all()
+    def prepare_package_entry(entry):
+        return {
+            'name': entry.name,
+            'collection': entry.collection_name,
+            'state': get_package_state(
+                tracked=entry.tracked,
+                blocked=entry.blocked,
+                resolved=entry.resolved,
+                last_complete_build_state=entry.last_complete_build_state,
+            ),
+            'last_complete_build': {
+                'task_id': entry.build_task_id,
+            } if entry.build_task_id is not None else None,
+        }
 
-    pkgs_with_complete_build = db.query(Package)\
-        .join(Build, Build.package_id == Package.id)\
-        .filter(Build.last_complete)\
-        .options(contains_eager(Package.last_complete_build))
-    pkgs_without_complete_build = db.query(Package)\
-        .filter(Package.last_complete_build_id == None)
-    packages = merge_sorted(*[run_query(query) for query in pkgs_with_complete_build,
-                            pkgs_without_complete_build],
-                            key=lambda p: p.name)
-    return jsonify(packages_to_json(packages))
+    query = (
+        db.query(
+            Package.name, Package.collection_id, Package.resolved,
+            Package.tracked, Package.blocked, Package.last_complete_build_state,
+            Build.task_id.label('build_task_id'),
+            Collection.name.label('collection_name'),
+        )
+        .outerjoin(
+            Build,
+            (Package.last_complete_build_id == Build.id) & Build.last_complete
+        )
+        .join(Collection)
+        .order_by(Package.name)
+    )
+    if 'name' in request.args:
+        query = query.filter(Package.name.in_(request.args.getlist('name')))
+    if 'collection' in request.args:
+        query = query.filter(Collection.name.in_(request.args.getlist('collection')))
+
+    return Response(
+        json.dumps([prepare_package_entry(p) for p in query]),
+        mimetype='application/json',
+    )

--- a/koschei/models.py
+++ b/koschei/models.py
@@ -704,6 +704,19 @@ Index('ix_builds_last_complete', Build.package_id, Build.task_id,
       postgresql_where=(Build.last_complete))
 
 
+# Auxiliary expressions
+Package.state_string_expression = case(
+    [
+        (Package.blocked, 'blocked'),
+        (~Package.tracked, 'untracked'),
+        (Package.resolved == False, 'unresolved'),
+        (Package.last_complete_build_state == Build.COMPLETE, 'ok'),
+        (Package.last_complete_build_state == Build.FAILED, 'failing'),
+    ],
+    else_='unknown',
+)
+
+
 # Relationships
 Package.last_complete_build = relationship(
     Build,


### PR DESCRIPTION
Attempt at optimizing the packages API endpoint. First I tried to rewrite it to use sqlalchemy core queries, that only return tuples, not ORM objects. I also turned off JSON pretty-printing.
I was surprised that even after that, it still was considerably slower than a simplified example that returned just name and task_id. It seems that even the trivial dictionary building happening there has a lot of overhead. I tried streaming the results, but it only made it worse. So I thought why not leaving all the dirty work to postgres. That's what the second commit does - all the json building happens in the DB, frontend just forwards it to the client as a string.

Timings on my machine (may not necessarily reflect production performance as I have an SSD):
```
master: 4.541s
with the first patch: 0.592s
with the second patch: 0.322s
```