### PR TITLE
[models] Try to unify multiple ways to compute state_string

### DIFF
--- a/koschei/frontend/api.py
+++ b/koschei/frontend/api.py
@@ -32,7 +32,8 @@ def list_packages():
         db.query(
             Package.name.label('name'),
             Collection.name.label('collection'),
-            Package.state_string_expression.label('state'),
+            # pylint:disable=no-member
+            Package.state_string.label('state'),
             sql_if(
                 Build.id != None,
                 db.query(Build.task_id.label('task_id'))

--- a/koschei/frontend/views.py
+++ b/koschei/frontend/views.py
@@ -41,7 +41,6 @@ from koschei.models import (
     BuildrootProblem, BasePackage, GroupACL, Collection, CollectionGroup,
     AppliedChange, UnappliedChange, ResolutionChange, ResourceConsumptionStats,
     ScalarStats,
-    get_package_state,
 )
 
 packages_per_page = frontend_config['packages_per_page']
@@ -912,12 +911,12 @@ def affected_by(dep_name):
         .all()
 
     def package_state(row):
-        return get_package_state(
+        return Package(
             tracked=True,
             blocked=False,
             resolved=row.package_resolved,
             last_complete_build_state=row.package_lb_state,
-        )
+        ).state_string
 
     return render_template("affected-by.html", package_state=package_state,
                            dep_name=dep_name, evr1=evr1, evr2=evr2,

--- a/test/common.py
+++ b/test/common.py
@@ -147,6 +147,7 @@ class DBTest(AbstractTest):
         super(DBTest, self).__init__(*args, **kwargs)
         self.db = None
         self.task_id_counter = 1
+        self.pkg_name_counter = 1
         self.collection = Collection(
             name="f25", display_name="Fedora Rawhide", target="f25",
             dest_tag='f25', build_tag="f25-build", priority_coefficient=1.0,
@@ -201,6 +202,18 @@ class DBTest(AbstractTest):
         self.db.add(build)
         self.db.commit()
         return pkg, build
+
+    def prepare_package(self, name=None, **kwargs):
+        if 'collection_id' not in kwargs:
+            kwargs['collection_id'] = self.collection.id
+        if not name:
+            name = 'p{}'.format(self.pkg_name_counter)
+            self.pkg_name_counter += 1
+        pkg = Package(name=name, **kwargs)
+        self.ensure_base_package(pkg)
+        self.db.add(pkg)
+        self.db.commit()
+        return pkg
 
     def prepare_packages(self, *pkg_names):
         pkgs = []

--- a/test/model_test.py
+++ b/test/model_test.py
@@ -91,6 +91,31 @@ class GroupTest(DBTest):
         self.assertEqual(0, group.package_count)
 
 
+class PackageStateStringTest(DBTest):
+    def verify_state_string(self, state_string, **pkg_kwargs):
+        pkg = self.prepare_package(**pkg_kwargs)
+        self.assertEqual(state_string, pkg.state_string)
+        self.assertEqual(
+            state_string,
+            self.db.query(Package.state_string)
+            .filter(Package.id == pkg.id)
+            .scalar()
+        )
+
+    def test_state_string(self):
+        self.verify_state_string('blocked', blocked=True)
+        self.verify_state_string('untracked', tracked=False)
+        self.verify_state_string('unresolved', resolved=False)
+        self.verify_state_string('ok', resolved=True,
+                                 last_complete_build_state=Build.COMPLETE)
+        self.verify_state_string('failing', resolved=True,
+                                 last_complete_build_state=Build.FAILED)
+        self.verify_state_string('unknown', resolved=None,
+                                 last_complete_build_state=None)
+        self.verify_state_string('unknown', resolved=True,
+                                 last_complete_build_state=None)
+
+
 @patch('sqlalchemy.sql.expression.func.clock_timestamp',
        return_value=literal_column("'2017-10-10 10:00:00'"))
 class PackagePriorityTest(DBTest):


### PR DESCRIPTION
There were two ways of computing package state_string:
- state_string instance method doing in python evaluation
- state_string_expression attribute doing the evaluation in the database

This attempts to unify them by keeping the SQL one and providing a basic
facility for in-python evaluation of such simple queries, based on
sqlachemy.evaluator