### PR TITLE
Query SRPM for requested architectures

### DIFF
--- a/config.cfg.template
+++ b/config.cfg.template
@@ -187,6 +187,10 @@ config = {
         "build_group": {
             "backend": "dogpile.cache.memory",
         },
+        "koji_arches": {
+            "backend": "dogpile.cache.memory",
+            "expiration_time": 3600,
+        },
         "rpm_requires": {
             "backend": "dogpile.cache.dbm",
             "expiration_time": None,

--- a/koschei/backend/__init__.py
+++ b/koschei/backend/__init__.py
@@ -94,19 +94,13 @@ class KoscheiBackendSession(KoscheiSession):
         return self._repo_cache
 
 
-def submit_build(session, package):
+def submit_build(session, package, arch_override=None):
     assert package.collection.latest_repo_id
     build = Build(package_id=package.id, state=Build.RUNNING)
     name = package.name
     build_opts = {}
-    if package.arch_override:
-        override = package.arch_override
-        if override.startswith('^'):
-            excludes = override[1:].split()
-            build_arches = get_config('koji_config').get('build_arches')
-            includes = set(build_arches) - set(excludes)
-            override = ' '.join(sorted(includes))
-        build_opts = {'arch_override': override}
+    if arch_override:
+        build_opts['arch_override'] = ' '.join(arch_override)
     # on secondary collections SRPMs are taken from secondary, primary
     # needs to be able to build from relative URL constructed against
     # secondary (internal redirect)

--- a/koschei/backend/koji_util.py
+++ b/koschei/backend/koji_util.py
@@ -234,8 +234,8 @@ def get_srpm_arches(koji_session, all_arches, nvra, arch_override=None):
     if arch_override:
         # we also allow inverse overrides
         if arch_override.startswith('^'):
-            archlist = [arch for arch in archlist
-                        if koji.canonArch(arch) not in arch_override[1:].split()]
+            excluded = {koji.canonArch(arch) for arch in arch_override[1:].split()}
+            archlist = [arch for arch in archlist if koji.canonArch(arch) not in excluded]
         else:
             archlist = arch_override.split()
 

--- a/koschei/backend/services/scheduler.py
+++ b/koschei/backend/services/scheduler.py
@@ -73,8 +73,11 @@ class Scheduler(Service):
             package = self.db.query(Package).get(package_id)
 
             koji_session = self.session.koji('primary')
-            build_config = koji_session.getBuildConfig(package.collection.build_tag)
-            all_arches = build_config['arches'].split()
+            all_arches = koji_util.get_koji_arches_cached(
+                self.session,
+                koji_session,
+                package.collection.build_tag,
+            )
             arches = koji_util.get_srpm_arches(
                 koji_session=koji_session,
                 all_arches=all_arches,

--- a/koschei/backend/services/scheduler.py
+++ b/koschei/backend/services/scheduler.py
@@ -22,7 +22,7 @@ from koschei import backend
 from koschei.config import get_config
 from koschei.backend import koji_util
 from koschei.backend.service import Service
-from koschei.models import Package, Build, Collection, KojiTask
+from koschei.models import Package, Build, Collection
 
 
 class Scheduler(Service):
@@ -43,6 +43,20 @@ class Scheduler(Service):
             .order_by(priority_expr.desc())\
             .all()
 
+    def skip_no_srpm(self, package):
+        self.log.info("No SRPM found for {} in {}"
+                      .format(package.name, package.collection.name))
+        package.scheduler_skip_reason = Package.SKIPPED_NO_SRPM
+        package.resolved = None
+        package.last_build_id = None
+        package.last_complete_build_id = None
+        package.last_complete_build_state = None
+        self.db.query(Build)\
+            .filter_by(package_id=package.id)\
+            .filter_by(last_complete=True)\
+            .update({'last_complete': False})
+        self.db.commit()
+
     def main(self):
         incomplete_builds_count = self.db.query(Build)\
             .filter(Build.state == Build.RUNNING)\
@@ -58,13 +72,32 @@ class Scheduler(Service):
                 return
             package = self.db.query(Package).get(package_id)
 
-            arches = self.db.query(KojiTask.arch)\
-                .filter_by(build_id=package.last_build_id)\
-                .all()
-            arches = [arch for [arch] in arches]
+            koji_session = self.session.koji('primary')
+            build_config = koji_session.getBuildConfig(package.collection.build_tag)
+            all_arches = build_config['arches'].split()
+            arches = koji_util.get_srpm_arches(
+                koji_session=koji_session,
+                all_arches=all_arches,
+                nvra=package.srpm_nvra,
+                arch_override=package.arch_override,
+            )
+            if arches is None:
+                self.skip_no_srpm(package)
+                continue
+            if not arches:
+                self.log.info("Skipping {}: no allowed arch".format(package.name))
+                package.scheduler_skip_reason = Package.SKIPPED_NO_ARCH
+                # FIXME we don't have a better way how to get package out of
+                # scheduler's way
+                package.manual_priority -= 1000
+                continue
             koji_load_threshold = get_config('koji_config.load_threshold')
             if koji_load_threshold < 1:
-                koji_load = koji_util.get_koji_load(self.session.koji('primary'), arches)
+                koji_load = koji_util.get_koji_load(
+                    koji_session=koji_session,
+                    all_arches=all_arches,
+                    arches=arches,
+                )
                 if koji_load > koji_load_threshold:
                     self.log.debug("Not scheduling {}: {} koji load"
                                    .format(package, koji_load))
@@ -72,24 +105,17 @@ class Scheduler(Service):
 
             self.log.info('Scheduling build for {} in {}, priority {}'
                           .format(package.name, package.collection.name, priority))
-            build = backend.submit_build(self.session, package)
+            build = backend.submit_build(
+                self.session,
+                package,
+                arch_override=None if 'noarch' in arches else arches,
+            )
             package.current_priority = None
             package.scheduler_skip_reason = None
             package.manual_priority = 0
 
             if not build:
-                self.log.info("No SRPM found for {} in {}"
-                              .format(package.name, package.collection.name))
-                package.scheduler_skip_reason = Package.SKIPPED_NO_SRPM
-                package.resolved = None
-                package.last_build_id = None
-                package.last_complete_build_id = None
-                package.last_complete_build_state = None
-                self.db.query(Build)\
-                    .filter_by(package_id=package_id)\
-                    .filter_by(last_complete=True)\
-                    .update({'last_complete': False})
-                self.db.commit()
+                self.skip_no_srpm(package)
                 continue
 
             self.db.commit()

--- a/koschei/models.py
+++ b/koschei/models.py
@@ -198,6 +198,7 @@ class Package(Base):
     blocked = Column(Boolean, nullable=False, server_default=false())
 
     SKIPPED_NO_SRPM = 1
+    SKIPPED_NO_ARCH = 2
     scheduler_skip_reason = Column(Integer)
 
     @classmethod
@@ -256,6 +257,8 @@ class Package(Base):
         reasons = []
         if self.scheduler_skip_reason == Package.SKIPPED_NO_SRPM:
             reasons.append("No suitable SRPM was found")
+        if self.scheduler_skip_reason == Package.SKIPPED_NO_ARCH:
+            reasons.append("No build architecture allowed for SRPM")
         if not self.tracked:
             reasons.append("Package is not tracked")
         if self.blocked:

--- a/test/backend_test.py
+++ b/test/backend_test.py
@@ -291,43 +291,15 @@ class BackendTest(DBTest):
 
     def test_submit_build_arch_override(self):
         package = self.prepare_packages('rnv')[0]
-        package.arch_override = 'x86_64 alpha'
+        arch_override = ['x86_64', 'alpha']
         self.db.commit()
         with patch('koschei.backend.koji_util.get_last_srpm', return_value=({'epoch': '111',
                                                                              'version': '222',
                                                                              'release': '333'}, 'the_url')) as get_last_srpm:
             with patch('koschei.backend.koji_util.koji_scratch_build', return_value=7541) as koji_scratch_build:
-                backend.submit_build(self.session, package)
+                backend.submit_build(self.session, package, arch_override=arch_override)
                 get_last_srpm.assert_called_once_with(self.session.sec_koji_mock, 'f25', 'rnv', relative=True)
                 koji_scratch_build.assert_called_once_with(self.session.koji_mock, 'f25', 'rnv', 'the_url', {'arch_override': 'x86_64 alpha'})
-        self.db.commit()
-        self.assertEqual(7541, package.last_build.task_id)
-
-    def test_submit_build_arch_exclude(self):
-        package = self.prepare_packages('rnv')[0]
-        package.arch_override = '^x86_64 alpha'
-        self.db.commit()
-        with patch('koschei.backend.koji_util.get_last_srpm', return_value=({'epoch': '111',
-                                                                             'version': '222',
-                                                                             'release': '333'}, 'the_url')) as get_last_srpm:
-            with patch('koschei.backend.koji_util.koji_scratch_build', return_value=7541) as koji_scratch_build:
-                backend.submit_build(self.session, package)
-                get_last_srpm.assert_called_once_with(self.session.sec_koji_mock, 'f25', 'rnv', relative=True)
-                koji_scratch_build.assert_called_once_with(self.session.koji_mock, 'f25', 'rnv', 'the_url', {'arch_override': 'armhfp i386'})
-        self.db.commit()
-        self.assertEqual(7541, package.last_build.task_id)
-
-    def test_submit_build_force_archful(self):
-        package = self.prepare_packages('rnv')[0]
-        package.arch_override = '^'
-        self.db.commit()
-        with patch('koschei.backend.koji_util.get_last_srpm', return_value=({'epoch': '111',
-                                                                             'version': '222',
-                                                                             'release': '333'}, 'the_url')) as get_last_srpm:
-            with patch('koschei.backend.koji_util.koji_scratch_build', return_value=7541) as koji_scratch_build:
-                backend.submit_build(self.session, package)
-                get_last_srpm.assert_called_once_with(self.session.sec_koji_mock, 'f25', 'rnv', relative=True)
-                koji_scratch_build.assert_called_once_with(self.session.koji_mock, 'f25', 'rnv', 'the_url', {'arch_override': 'armhfp i386 x86_64'})
         self.db.commit()
         self.assertEqual(7541, package.last_build.task_id)
 
@@ -344,4 +316,3 @@ class BackendTest(DBTest):
         self.db.commit()
         self.assertEqual(7541, package.last_build.task_id)
         self.assertEqual(123, package.last_build.repo_id)
-

--- a/test/data/get_srpm_arches.vcr.json
+++ b/test/data/get_srpm_arches.vcr.json
@@ -1,0 +1,70 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "body": "<?xml version='1.0'?>\n<methodCall>\n<methodName>getRPMHeaders</methodName>\n<params>\n<param>\n<value><struct>\n<member>\n<name>__starstar</name>\n<value><boolean>1</boolean></value>\n</member>\n<member>\n<name>headers</name>\n<value><array><data>\n<value><string>BUILDARCHS</string></value>\n<value><string>EXCLUDEARCH</string></value>\n<value><string>EXCLUSIVEARCH</string></value>\n</data></array></value>\n</member>\n<member>\n<name>rpmID</name>\n<value><struct>\n<member>\n<name>release</name>\n<value><string>11.fc26</string></value>\n</member>\n<member>\n<name>version</name>\n<value><string>1.7.11</string></value>\n</member>\n<member>\n<name>arch</name>\n<value><string>src</string></value>\n</member>\n<member>\n<name>name</name>\n<value><string>rnv</string></value>\n</member>\n</struct></value>\n</member>\n</struct></value>\n</param>\n</params>\n</methodCall>\n",
+                "headers": {
+                    "Content-Length": [
+                        "832"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "User-Agent": [
+                        "koji/1.7"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "Content-Type": [
+                        "text/xml"
+                    ]
+                },
+                "method": "POST",
+                "uri": "https://koji.fedoraproject.org/kojihub"
+            },
+            "response": {
+                "status": {
+                    "message": "OK",
+                    "code": 200
+                },
+                "headers": {
+                    "apptime": [
+                        "D=1483668"
+                    ],
+                    "content-length": [
+                        "395"
+                    ],
+                    "strict-transport-security": [
+                        "max-age=15768000; includeSubDomains; preload"
+                    ],
+                    "keep-alive": [
+                        "timeout=15, max=500"
+                    ],
+                    "server": [
+                        "Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0 mod_auth_kerb/5.4 mod_wsgi/3.4 Python/2.7.5"
+                    ],
+                    "appserver": [
+                        "proxy01.phx2.fedoraproject.org"
+                    ],
+                    "connection": [
+                        "Keep-Alive"
+                    ],
+                    "date": [
+                        "Mon, 03 Jul 2017 15:57:28 GMT"
+                    ],
+                    "content-type": [
+                        "text/xml"
+                    ]
+                },
+                "body": {
+                    "string": "<?xml version='1.0'?>\n<methodResponse>\n<params>\n<param>\n<value><struct>\n<member>\n<name>BUILDARCHS</name>\n<value><array><data>\n</data></array></value>\n</member>\n<member>\n<name>EXCLUDEARCH</name>\n<value><array><data>\n</data></array></value>\n</member>\n<member>\n<name>EXCLUSIVEARCH</name>\n<value><array><data>\n</data></array></value>\n</member>\n</struct></value>\n</param>\n</params>\n</methodResponse>\n"
+                }
+            }
+        }
+    ]
+}

--- a/test/data/get_srpm_arches_exclude.vcr.json
+++ b/test/data/get_srpm_arches_exclude.vcr.json
@@ -1,0 +1,70 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "body": "<?xml version='1.0'?>\n<methodCall>\n<methodName>getRPMHeaders</methodName>\n<params>\n<param>\n<value><struct>\n<member>\n<name>__starstar</name>\n<value><boolean>1</boolean></value>\n</member>\n<member>\n<name>headers</name>\n<value><array><data>\n<value><string>BUILDARCHS</string></value>\n<value><string>EXCLUDEARCH</string></value>\n<value><string>EXCLUSIVEARCH</string></value>\n</data></array></value>\n</member>\n<member>\n<name>rpmID</name>\n<value><struct>\n<member>\n<name>release</name>\n<value><string>0.20170221git663ebfd.0.fc25</string></value>\n</member>\n<member>\n<name>version</name>\n<value><string>0.34dev</string></value>\n</member>\n<member>\n<name>arch</name>\n<value><string>src</string></value>\n</member>\n<member>\n<name>name</name>\n<value><string>ghdl</string></value>\n</member>\n</struct></value>\n</member>\n</struct></value>\n</param>\n</params>\n</methodCall>\n",
+                "headers": {
+                    "Content-Length": [
+                        "854"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "User-Agent": [
+                        "koji/1.7"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "Content-Type": [
+                        "text/xml"
+                    ]
+                },
+                "method": "POST",
+                "uri": "https://koji.fedoraproject.org/kojihub"
+            },
+            "response": {
+                "status": {
+                    "message": "OK",
+                    "code": 200
+                },
+                "headers": {
+                    "apptime": [
+                        "D=163717"
+                    ],
+                    "content-length": [
+                        "1527"
+                    ],
+                    "strict-transport-security": [
+                        "max-age=15768000; includeSubDomains; preload"
+                    ],
+                    "keep-alive": [
+                        "timeout=15, max=500"
+                    ],
+                    "server": [
+                        "Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0 mod_auth_kerb/5.4 mod_wsgi/3.4 Python/2.7.5"
+                    ],
+                    "appserver": [
+                        "proxy01.phx2.fedoraproject.org"
+                    ],
+                    "connection": [
+                        "Keep-Alive"
+                    ],
+                    "date": [
+                        "Mon, 03 Jul 2017 15:57:30 GMT"
+                    ],
+                    "content-type": [
+                        "text/xml"
+                    ]
+                },
+                "body": {
+                    "string": "<?xml version='1.0'?>\n<methodResponse>\n<params>\n<param>\n<value><struct>\n<member>\n<name>BUILDARCHS</name>\n<value><array><data>\n</data></array></value>\n</member>\n<member>\n<name>EXCLUDEARCH</name>\n<value><array><data>\n<value><string>armv7hl</string></value>\n</data></array></value>\n</member>\n<member>\n<name>EXCLUSIVEARCH</name>\n<value><array><data>\n<value><string>i386</string></value>\n<value><string>i486</string></value>\n<value><string>i586</string></value>\n<value><string>i686</string></value>\n<value><string>pentium3</string></value>\n<value><string>pentium4</string></value>\n<value><string>athlon</string></value>\n<value><string>geode</string></value>\n<value><string>x86_64</string></value>\n<value><string>ppc64</string></value>\n<value><string>ppc64p7</string></value>\n<value><string>ppc64le</string></value>\n<value><string>s390x</string></value>\n<value><string>armv3l</string></value>\n<value><string>armv4b</string></value>\n<value><string>armv4l</string></value>\n<value><string>armv4tl</string></value>\n<value><string>armv5tel</string></value>\n<value><string>armv5tejl</string></value>\n<value><string>armv6l</string></value>\n<value><string>armv6hl</string></value>\n<value><string>armv7l</string></value>\n<value><string>armv7hl</string></value>\n<value><string>armv7hnl</string></value>\n<value><string>aarch64</string></value>\n<value><string>ia64</string></value>\n<value><string>ppc</string></value>\n<value><string>alpha</string></value>\n</data></array></value>\n</member>\n</struct></value>\n</param>\n</params>\n</methodResponse>\n"
+                }
+            }
+        }
+    ]
+}

--- a/test/data/get_srpm_arches_exclusive.vcr.json
+++ b/test/data/get_srpm_arches_exclusive.vcr.json
@@ -1,0 +1,70 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "body": "<?xml version='1.0'?>\n<methodCall>\n<methodName>getRPMHeaders</methodName>\n<params>\n<param>\n<value><struct>\n<member>\n<name>__starstar</name>\n<value><boolean>1</boolean></value>\n</member>\n<member>\n<name>headers</name>\n<value><array><data>\n<value><string>BUILDARCHS</string></value>\n<value><string>EXCLUDEARCH</string></value>\n<value><string>EXCLUSIVEARCH</string></value>\n</data></array></value>\n</member>\n<member>\n<name>rpmID</name>\n<value><struct>\n<member>\n<name>release</name>\n<value><string>2.170420.fc26</string></value>\n</member>\n<member>\n<name>epoch</name>\n<value><int>1</int></value>\n</member>\n<member>\n<name>version</name>\n<value><string>1.8.0.131</string></value>\n</member>\n<member>\n<name>arch</name>\n<value><string>src</string></value>\n</member>\n<member>\n<name>name</name>\n<value><string>java-1.8.0-openjdk-aarch32</string></value>\n</member>\n</struct></value>\n</member>\n</struct></value>\n</param>\n</params>\n</methodCall>\n",
+                "headers": {
+                    "Content-Length": [
+                        "930"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "User-Agent": [
+                        "koji/1.7"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "Content-Type": [
+                        "text/xml"
+                    ]
+                },
+                "method": "POST",
+                "uri": "https://koji.fedoraproject.org/kojihub"
+            },
+            "response": {
+                "status": {
+                    "message": "OK",
+                    "code": 200
+                },
+                "headers": {
+                    "apptime": [
+                        "D=77631"
+                    ],
+                    "content-length": [
+                        "834"
+                    ],
+                    "strict-transport-security": [
+                        "max-age=15768000; includeSubDomains; preload"
+                    ],
+                    "keep-alive": [
+                        "timeout=15, max=500"
+                    ],
+                    "server": [
+                        "Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0 mod_auth_kerb/5.4 mod_wsgi/3.4 Python/2.7.5"
+                    ],
+                    "appserver": [
+                        "proxy01.phx2.fedoraproject.org"
+                    ],
+                    "connection": [
+                        "Keep-Alive"
+                    ],
+                    "date": [
+                        "Mon, 03 Jul 2017 15:57:31 GMT"
+                    ],
+                    "content-type": [
+                        "text/xml"
+                    ]
+                },
+                "body": {
+                    "string": "<?xml version='1.0'?>\n<methodResponse>\n<params>\n<param>\n<value><struct>\n<member>\n<name>BUILDARCHS</name>\n<value><array><data>\n</data></array></value>\n</member>\n<member>\n<name>EXCLUDEARCH</name>\n<value><array><data>\n</data></array></value>\n</member>\n<member>\n<name>EXCLUSIVEARCH</name>\n<value><array><data>\n<value><string>armv3l</string></value>\n<value><string>armv4b</string></value>\n<value><string>armv4l</string></value>\n<value><string>armv4tl</string></value>\n<value><string>armv5tel</string></value>\n<value><string>armv5tejl</string></value>\n<value><string>armv6l</string></value>\n<value><string>armv6hl</string></value>\n<value><string>armv7l</string></value>\n<value><string>armv7hl</string></value>\n<value><string>armv7hnl</string></value>\n</data></array></value>\n</member>\n</struct></value>\n</param>\n</params>\n</methodResponse>\n"
+                }
+            }
+        }
+    ]
+}

--- a/test/data/get_srpm_arches_noarch.vcr.json
+++ b/test/data/get_srpm_arches_noarch.vcr.json
@@ -1,0 +1,70 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "body": "<?xml version='1.0'?>\n<methodCall>\n<methodName>getRPMHeaders</methodName>\n<params>\n<param>\n<value><struct>\n<member>\n<name>__starstar</name>\n<value><boolean>1</boolean></value>\n</member>\n<member>\n<name>headers</name>\n<value><array><data>\n<value><string>BUILDARCHS</string></value>\n<value><string>EXCLUDEARCH</string></value>\n<value><string>EXCLUSIVEARCH</string></value>\n</data></array></value>\n</member>\n<member>\n<name>rpmID</name>\n<value><struct>\n<member>\n<name>release</name>\n<value><string>9.fc26</string></value>\n</member>\n<member>\n<name>version</name>\n<value><string>3.3.9</string></value>\n</member>\n<member>\n<name>arch</name>\n<value><string>src</string></value>\n</member>\n<member>\n<name>name</name>\n<value><string>maven</string></value>\n</member>\n</struct></value>\n</member>\n</struct></value>\n</param>\n</params>\n</methodCall>\n",
+                "headers": {
+                    "Content-Length": [
+                        "832"
+                    ],
+                    "Accept-Encoding": [
+                        "gzip, deflate"
+                    ],
+                    "Accept": [
+                        "*/*"
+                    ],
+                    "User-Agent": [
+                        "koji/1.7"
+                    ],
+                    "Connection": [
+                        "keep-alive"
+                    ],
+                    "Content-Type": [
+                        "text/xml"
+                    ]
+                },
+                "method": "POST",
+                "uri": "https://koji.fedoraproject.org/kojihub"
+            },
+            "response": {
+                "status": {
+                    "message": "OK",
+                    "code": 200
+                },
+                "headers": {
+                    "apptime": [
+                        "D=152189"
+                    ],
+                    "content-length": [
+                        "434"
+                    ],
+                    "strict-transport-security": [
+                        "max-age=15768000; includeSubDomains; preload"
+                    ],
+                    "keep-alive": [
+                        "timeout=15, max=500"
+                    ],
+                    "server": [
+                        "Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.1e-fips mod_auth_gssapi/1.4.0 mod_auth_kerb/5.4 mod_wsgi/3.4 Python/2.7.5"
+                    ],
+                    "appserver": [
+                        "proxy01.phx2.fedoraproject.org"
+                    ],
+                    "connection": [
+                        "Keep-Alive"
+                    ],
+                    "date": [
+                        "Mon, 03 Jul 2017 15:57:32 GMT"
+                    ],
+                    "content-type": [
+                        "text/xml"
+                    ]
+                },
+                "body": {
+                    "string": "<?xml version='1.0'?>\n<methodResponse>\n<params>\n<param>\n<value><struct>\n<member>\n<name>BUILDARCHS</name>\n<value><array><data>\n<value><string>noarch</string></value>\n</data></array></value>\n</member>\n<member>\n<name>EXCLUDEARCH</name>\n<value><array><data>\n</data></array></value>\n</member>\n<member>\n<name>EXCLUSIVEARCH</name>\n<value><array><data>\n</data></array></value>\n</member>\n</struct></value>\n</param>\n</params>\n</methodResponse>\n"
+                }
+            }
+        }
+    ]
+}

--- a/test/koji_util_test.py
+++ b/test/koji_util_test.py
@@ -103,6 +103,16 @@ class KojiArchesTest(AbstractTest):
         )
 
     @my_vcr.use_cassette('get_srpm_arches')
+    def test_get_srpm_arches_override_non_canon(self):
+        nvra = {'arch': 'src', 'name': 'rnv', 'release': '11.fc26',
+                'version': '1.7.11'}
+        self.assertEqual(
+            {'i686'},
+            koji_util.get_srpm_arches(self.session, self.all_arches, nvra,
+                                      arch_override="i686"),
+        )
+
+    @my_vcr.use_cassette('get_srpm_arches')
     def test_get_srpm_arches_override_inv(self):
         nvra = {'arch': 'src', 'name': 'rnv', 'release': '11.fc26',
                 'version': '1.7.11'}
@@ -110,4 +120,14 @@ class KojiArchesTest(AbstractTest):
             {'i686', 'x86_64'},
             koji_util.get_srpm_arches(self.session, self.all_arches, nvra,
                                       arch_override="^armhfp"),
+        )
+
+    @my_vcr.use_cassette('get_srpm_arches')
+    def test_get_srpm_arches_override_inv_non_canon(self):
+        nvra = {'arch': 'src', 'name': 'rnv', 'release': '11.fc26',
+                'version': '1.7.11'}
+        self.assertEqual(
+            {'i686', 'x86_64'},
+            koji_util.get_srpm_arches(self.session, self.all_arches, nvra,
+                                      arch_override="^armv7hl"),
         )

--- a/test/koji_util_test.py
+++ b/test/koji_util_test.py
@@ -26,22 +26,88 @@ class KojiUtilTest(AbstractTest):
     def setUp(self):
         self.session = koji.ClientSession('https://koji.stg.fedoraproject.org/kojihub')
 
+    all_arches = ['i386', 'x86_64', 'armhfp']
+
     @my_vcr.use_cassette('koji_load_all')
     def test_koji_load_all(self):
-        load = koji_util.get_koji_load(self.session, [])
+        load = koji_util.get_koji_load(self.session, self.all_arches, self.all_arches)
         self.assertAlmostEqual(0.8958, load, 4)
 
     @my_vcr.use_cassette('koji_load_noarch')
     def test_koji_load_noarch(self):
-        load = koji_util.get_koji_load(self.session, ['noarch'])
+        load = koji_util.get_koji_load(self.session, self.all_arches, ['noarch'])
         self.assertAlmostEqual(0.4305, load, 4)
 
     @my_vcr.use_cassette('koji_load_intel')
     def test_koji_load_intel(self):
-        load = koji_util.get_koji_load(self.session, ['i386', 'x86_64'])
+        load = koji_util.get_koji_load(self.session, self.all_arches, ['i686', 'x86_64'])
         self.assertAlmostEqual(0.5119, load, 4)
 
     @my_vcr.use_cassette('koji_load_arm')
     def test_koji_load_arm(self):
-        load = koji_util.get_koji_load(self.session, ['aarch64', 'armhfp'])
+        load = koji_util.get_koji_load(self.session, self.all_arches, ['armv7hl'])
         self.assertAlmostEqual(0.8958, load, 4)
+
+
+class KojiArchesTest(AbstractTest):
+    def setUp(self):
+        self.session = koji.ClientSession('https://koji.fedoraproject.org/kojihub')
+
+    all_arches = ['aarch64', 'armv7hl', 'i686', 'ppc64', 'ppc64le', 's390x', 'x86_64']
+    # allowed by koschei config = ['i386', 'x86_64', 'armhfp']
+
+    @my_vcr.use_cassette('get_srpm_arches')
+    def test_get_srpm_arches(self):
+        nvra = {'arch': 'src', 'name': 'rnv', 'release': '11.fc26',
+                'version': '1.7.11'}
+        self.assertEqual(
+            {'i686', 'x86_64', 'armv7hl'},
+            koji_util.get_srpm_arches(self.session, self.all_arches, nvra),
+        )
+
+    @my_vcr.use_cassette('get_srpm_arches_noarch')
+    def test_get_srpm_arches_noarch(self):
+        nvra = {'arch': 'src', 'name': 'maven', 'release': '9.fc26',
+                'version': '3.3.9'}
+        self.assertEqual(
+            {'noarch'},
+            koji_util.get_srpm_arches(self.session, self.all_arches, nvra),
+        )
+
+    @my_vcr.use_cassette('get_srpm_arches_exclusive')
+    def test_get_srpm_arches_exclusive(self):
+        nvra = {'name': 'java-1.8.0-openjdk-aarch32', 'version': '1.8.0.131',
+                'release': '2.170420.fc26', 'epoch': 1, 'arch': 'src'}
+        self.assertEqual(
+            {'armv7hl'},
+            koji_util.get_srpm_arches(self.session, self.all_arches, nvra),
+        )
+
+    @my_vcr.use_cassette('get_srpm_arches_exclude')
+    def test_get_srpm_arches_exclude(self):
+        nvra = {'name': 'ghdl', 'version': '0.34dev',
+                'release': '0.20170221git663ebfd.0.fc25', 'arch': 'src'}
+        self.assertEqual(
+            {'i686', 'x86_64'},
+            koji_util.get_srpm_arches(self.session, self.all_arches, nvra),
+        )
+
+    @my_vcr.use_cassette('get_srpm_arches')
+    def test_get_srpm_arches_override(self):
+        nvra = {'arch': 'src', 'name': 'rnv', 'release': '11.fc26',
+                'version': '1.7.11'}
+        self.assertEqual(
+            {'i386', 'x86_64'},
+            koji_util.get_srpm_arches(self.session, self.all_arches, nvra,
+                                      arch_override="x86_64 i386"),
+        )
+
+    @my_vcr.use_cassette('get_srpm_arches')
+    def test_get_srpm_arches_override_inv(self):
+        nvra = {'arch': 'src', 'name': 'rnv', 'release': '11.fc26',
+                'version': '1.7.11'}
+        self.assertEqual(
+            {'i686', 'x86_64'},
+            koji_util.get_srpm_arches(self.session, self.all_arches, nvra,
+                                      arch_override="^armhfp"),
+        )


### PR DESCRIPTION
Recently, Koji started lying about arch of noarch builds of packages
that have arch exclusions, such as [0] (is noarch, but reports arch=i386).
This attempts to use data from SRPM headers to determine whether
a package is noarch and on which architectures it should be built.
Also skips packages for which the arch list was empty (no allowed arch).

[0] https://koji.fedoraproject.org/koji/taskinfo?taskID=19927957