### PR TITLE
[frontend] Require authentication for long-running queries

### DIFF
--- a/koschei/frontend/views.py
+++ b/koschei/frontend/views.py
@@ -627,6 +627,7 @@ def group_detail(name=None, namespace=None):
 @app.route('/user/<username>')
 @package_tab
 @my_packages_tab.master
+@auth.login_required()
 def user_packages(username):
     names = []
     try:
@@ -885,6 +886,7 @@ def edit_collection(name):
 
 
 @app.route('/affected-by/<dep_name>')
+@auth.login_required()
 def affected_by(dep_name):
     if len(g.current_collections) != 1:
         abort(400)

--- a/test/frontend_test.py
+++ b/test/frontend_test.py
@@ -402,6 +402,31 @@ class FrontendTest(DBTest):
             self.db.query(PackageGroup).filter_by(name='foo').count(),
         )
 
+    def test_affected_by_unauthenticated(self):
+        # bar was broken
+        b1 = self.prepare_build('bar', True)
+        b2 = self.prepare_build('bar', False)
+        self.db.add(AppliedChange(
+            build_id=b2.id,
+            dep_name='foo', distance=3,
+            prev_epoch=0, prev_version='1.2', prev_release='3',
+            curr_epoch=0, curr_version='4.5', curr_release='6',
+        ))
+        self.db.commit()
+        reply = self.client.get(
+            'affected-by/foo'+
+            '?collection=f25' +
+            '&epoch1=0' +
+            '&version1=1.2' +
+            '&release1=3' +
+            '&epoch2=0' +
+            '&version2=4.5' +
+            '&release2=6'
+        )
+        self.assertEqual(302, reply.status_code)
+        self.assertEqual("http://localhost/login?", reply.location[:23])
+
+    @authenticate
     def test_affected_by_one(self):
         # bar was broken
         b1 = self.prepare_build('bar', True)


### PR DESCRIPTION
Pages that require long-running queries to DB (affected-by
functionality) or other external services (showing user packages)
should be limited to authenticated users.  Otherwise they could be
abused to cause denial of service.