### PR TITLE
Restructure applied change

### DIFF
--- a/alembic/versions/6d4894cd2307_reference_dependency_from_depchanges.py
+++ b/alembic/versions/6d4894cd2307_reference_dependency_from_depchanges.py
@@ -1,0 +1,122 @@
+"""
+Reference dependency from depchanges
+
+Create Date: 2017-09-04 11:49:48.305676
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '6d4894cd2307'
+down_revision = '0300b36eeaf4'
+
+from alembic import op
+
+
+def upgrade():
+    op.execute("""
+        INSERT INTO dependency(name, epoch, version, release, arch)
+            SELECT dep_name, prev_epoch, prev_version, prev_release, 'x86_64'
+            FROM (
+                (
+                    SELECT DISTINCT dep_name, prev_epoch, prev_version, prev_release
+                        FROM applied_change
+                        WHERE prev_version IS NOT NULL
+                ) UNION (
+                    SELECT DISTINCT dep_name, curr_epoch, curr_version, curr_release
+                        FROM applied_change
+                        WHERE curr_version IS NOT NULL
+                ) EXCEPT (
+                    SELECT name, epoch, version, release FROM dependency
+                )
+            ) as deps;
+
+        CREATE SEQUENCE applied_change2_id_seq;
+
+        CREATE TABLE applied_change2 AS
+            SELECT nextval('applied_change2_id_seq') as id,
+                build_id,
+                (
+                    SELECT id FROM dependency
+                    WHERE dep_name = name
+                      AND prev_version = version
+                      AND prev_epoch = epoch
+                      AND prev_release = release
+                ) AS prev_dep_id,
+                (
+                    SELECT id FROM dependency
+                    WHERE dep_name = name
+                      AND curr_version = version
+                      AND curr_epoch = epoch
+                      AND curr_release = release
+                ) AS curr_dep_id,
+                distance
+            FROM applied_change;
+
+        ALTER TABLE applied_change2
+            ADD PRIMARY KEY(id),
+            ALTER COLUMN id SET DEFAULT nextval('applied_change2_id_seq'::regclass),
+            ALTER COLUMN build_id SET NOT NULL,
+            ADD CONSTRAINT applied_change_build_id_fkey
+                FOREIGN KEY (build_id)
+                REFERENCES build(id) ON DELETE CASCADE,
+            ADD CONSTRAINT applied_change_prev_dep_id_fkey
+                FOREIGN KEY (prev_dep_id)
+                REFERENCES dependency(id),
+            ADD CONSTRAINT applied_change_curr_dep_id_fkey
+                FOREIGN KEY (curr_dep_id)
+                REFERENCES dependency(id),
+            ADD CONSTRAINT applied_change_dep_id_check
+            CHECK (COALESCE(prev_dep_id, 0) <> COALESCE(curr_dep_id, 0));
+        ALTER SEQUENCE applied_change2_id_seq OWNED BY applied_change2.id;
+        -- the indices should be droppped automatically, but BDR doesn't do that
+        DROP INDEX ix_applied_change_dep_name;
+        DROP INDEX ix_applied_change_build_id;
+        DROP TABLE applied_change;
+        DROP TYPE IF EXISTS applied_change; -- BDR-specific hack
+        DROP SEQUENCE IF EXISTS applied_change_id_seq;
+        ALTER TABLE applied_change2 RENAME TO applied_change;
+        ALTER INDEX applied_change2_pkey RENAME TO applied_change_pkey;
+        ALTER SEQUENCE applied_change2_id_seq RENAME TO applied_change_id_seq;
+
+        CREATE INDEX ix_applied_change_build_id ON applied_change(build_id);
+        CREATE INDEX ix_applied_change_prev_dep_id ON applied_change(prev_dep_id);
+        CREATE INDEX ix_applied_change_curr_dep_id ON applied_change(curr_dep_id);
+    """)
+
+
+def downgrade():
+    op.execute("""
+        CREATE TABLE applied_change2 AS
+            SELECT change.id AS id,
+                   change.build_id AS build_id,
+                   COALESCE(prev.name, curr.name) AS dep_name,
+                   prev.epoch AS prev_epoch,
+                   prev.version AS prev_version,
+                   prev.release AS prev_release,
+                   curr.epoch AS curr_epoch,
+                   curr.version AS curr_version,
+                   curr.release AS curr_release,
+                   change.distance AS distance
+                FROM applied_change AS change
+                     LEFT JOIN dependency AS prev ON prev.id = prev_dep_id
+                     LEFT JOIN dependency AS curr ON curr.id = curr_dep_id;
+
+        ALTER TABLE applied_change2
+            ADD PRIMARY KEY(id),
+            ALTER COLUMN id SET DEFAULT nextval('applied_change_id_seq'::regclass),
+            ALTER COLUMN build_id SET NOT NULL,
+            ADD CONSTRAINT applied_change_build_id_fkey
+                FOREIGN KEY (build_id)
+                REFERENCES build(id) ON DELETE CASCADE,
+            ALTER COLUMN dep_name SET NOT NULL;
+
+        ALTER SEQUENCE applied_change_id_seq OWNED BY applied_change2.id;
+        DROP INDEX ix_applied_change_build_id;
+        DROP TABLE applied_change;
+        DROP TYPE IF EXISTS applied_change; -- BDR-specific hack
+        ALTER TABLE applied_change2 RENAME TO applied_change;
+        ALTER INDEX applied_change2_pkey RENAME TO applied_change_pkey;
+
+        CREATE INDEX ix_applied_change_build_id ON applied_change(build_id);
+        CREATE INDEX ix_applied_change_dep_name ON applied_change(dep_name);
+    """)

--- a/koschei/data.py
+++ b/koschei/data.py
@@ -142,8 +142,9 @@ def copy_collection(session, source, copy):
             if c.name != 'id' and c.name not in exclude
         )
 
-    def deepcopy_table(entity, whereclause=''):
-        foreign_keys = entity.__table__.foreign_keys
+    def deepcopy_table(entity, whereclause='', foreign_keys=None):
+        if not foreign_keys:
+            foreign_keys = entity.__table__.foreign_keys
         assert len(foreign_keys) == 1
         foreign_key = next(iter(foreign_keys))
         parent = foreign_key.column.table
@@ -215,4 +216,7 @@ def copy_collection(session, source, copy):
     deepcopy_table(KojiTask)
     deepcopy_table(ResolutionChange)
     deepcopy_table(ResolutionProblem)
-    deepcopy_table(AppliedChange)
+    deepcopy_table(
+        AppliedChange,
+        foreign_keys=AppliedChange.__table__.c.build_id.foreign_keys,
+    )

--- a/koschei/models.py
+++ b/koschei/models.py
@@ -511,44 +511,58 @@ class Dependency(Base):
     release = Column(String, nullable=False)
     arch = Column(String, nullable=False)
 
+    evr = composite(
+        RpmEVR, epoch, version, release,
+        comparator_factory=RpmEVRComparator,
+    )
+
     nevr = (name, epoch, version, release)
     nevra = (name, epoch, version, release, arch)
     inevra = (id, name, epoch, version, release, arch)
 
 
 class AppliedChange(Base):
+    __table_args__ = (
+        CheckConstraint(
+            'COALESCE(prev_dep_id, 0) <> COALESCE(curr_dep_id, 0)',
+            name='applied_change_dep_id_check'
+        ),
+    )
+
     id = Column(Integer, primary_key=True)
-    dep_name = Column(String, nullable=False)
-    prev_epoch = Column(Integer)
-    prev_version = Column(String)
-    prev_release = Column(String)
-    curr_epoch = Column(Integer)
-    curr_version = Column(String)
-    curr_release = Column(String)
+    build_id = Column(
+        ForeignKey('build.id', ondelete='CASCADE'),
+        index=True,
+        nullable=False,
+    )
+    prev_dep_id = Column(Integer, ForeignKey('dependency.id'), index=True)
+    prev_dep = relationship(
+        Dependency,
+        foreign_keys=prev_dep_id,
+        uselist=False,
+        lazy='joined',
+    )
+    curr_dep_id = Column(Integer, ForeignKey('dependency.id'), index=True)
+    curr_dep = relationship(
+        Dependency,
+        foreign_keys=curr_dep_id,
+        uselist=False,
+        lazy='joined',
+    )
     distance = Column(Integer)
-
-    build_id = Column(ForeignKey('build.id', ondelete='CASCADE'), index=True,
-                      nullable=False)
     build = None  # backref
-    _prev_evr = composite(
-        RpmEVR,
-        prev_epoch, prev_version, prev_release,
-        comparator_factory=RpmEVRComparator,
-    )
 
-    @hybrid_property
+    @property
+    def dep_name(self):
+        return self.curr_dep.name if self.curr_dep else self.prev_dep.name
+
+    @property
     def prev_evr(self):
-        return self._prev_evr if self.prev_version else None
+        return self.prev_dep.evr if self.prev_dep else None
 
-    _curr_evr = composite(
-        RpmEVR,
-        curr_epoch, curr_version, curr_release,
-        comparator_factory=RpmEVRComparator,
-    )
-
-    @hybrid_property
+    @property
     def curr_evr(self):
-        return self._curr_evr if self.curr_version else None
+        return self.curr_dep.evr if self.curr_dep else None
 
     @property
     def package(self):
@@ -746,7 +760,6 @@ Index('ix_package_group_name', PackageGroup.namespace, PackageGroup.name,
 Index('ix_dependency_composite', *Dependency.nevra, unique=True)
 Index('ix_package_collection_id', Package.collection_id, Package.tracked,
       postgresql_where=(~Package.blocked))
-Index('ix_applied_change_dep_name', AppliedChange.dep_name)
 Index('ix_builds_unprocessed', Build.task_id,
       postgresql_where=(Build.deps_resolved.is_(None) & Build.repo_id.isnot(None)))
 Index('ix_builds_last_complete', Build.package_id, Build.task_id,

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -214,12 +214,12 @@
     <a href="{{ url_for(
              'affected_by',
              dep_name=change.dep_name,
-             epoch1=change.prev_epoch or '0',
-             version1=change.prev_version,
-             release1=change.prev_release,
-             epoch2=change.curr_epoch or '0',
-             version2=change.curr_version,
-             release2=change.curr_release,
+             epoch1=change.prev_evr.epoch or '0',
+             version1=change.prev_evr.version,
+             release1=change.prev_evr.release,
+             epoch2=change.curr_evr.epoch or '0',
+             version2=change.curr_evr.version,
+             release2=change.curr_evr.release,
              collection=change.package.collection.name,
              ) }}">
       <i class="fa fa-question-circle-o" data-toggle="tooltip" data-placement="right"

--- a/test/data_test.py
+++ b/test/data_test.py
@@ -26,7 +26,7 @@ from datetime import datetime
 from test.common import DBTest
 from koschei.models import (
     PackageGroup, PackageGroupRelation, Collection, Package, AppliedChange,
-    KojiTask, ResolutionChange, ResolutionProblem,
+    KojiTask, ResolutionChange, ResolutionProblem, Dependency
 )
 from koschei import data
 
@@ -103,10 +103,16 @@ class DataTest(DBTest):
             dest_tag='c',
         )
         self.db.add(copy)
+        prev_dep = Dependency(
+            name='foo', version='1', release='1', arch='x86_64'
+        )
+        curr_dep = Dependency(
+            name='foo', version='1', release='2', arch='x86_64'
+        )
         change1 = AppliedChange(
-            dep_name='foo', build_id=old_build1.id,
-            prev_version='1', prev_release='1',
-            curr_version='1', curr_release='2',
+            build_id=old_build1.id,
+            prev_dep=prev_dep,
+            curr_dep=curr_dep,
         )
         self.db.add(change1)
         task1 = KojiTask(
@@ -153,7 +159,7 @@ class DataTest(DBTest):
 
         self.assertEqual(1, len(old_build2.dependency_changes))
         change2 = old_build2.dependency_changes[0]
-        self.assertEqual('2', change2.curr_release)
+        self.assertEqual('2', change2.curr_dep.release)
 
         rchange2 = self.db.query(ResolutionChange).filter_by(package_id=maven2.id).one()
         self.assertEqual("It's broken", rchange2.problems[0].problem)

--- a/test/frontend_test.py
+++ b/test/frontend_test.py
@@ -406,12 +406,12 @@ class FrontendTest(DBTest):
         # bar was broken
         b1 = self.prepare_build('bar', True)
         b2 = self.prepare_build('bar', False)
-        self.db.add(AppliedChange(
+        self.prepare_depchange(
             build_id=b2.id,
             dep_name='foo', distance=3,
             prev_epoch=0, prev_version='1.2', prev_release='3',
             curr_epoch=0, curr_version='4.5', curr_release='6',
-        ))
+        )
         self.db.commit()
         reply = self.client.get(
             'affected-by/foo'+
@@ -431,66 +431,66 @@ class FrontendTest(DBTest):
         # bar was broken
         b1 = self.prepare_build('bar', True)
         b2 = self.prepare_build('bar', False)
-        self.db.add(AppliedChange(
+        self.prepare_depchange(
             build_id=b2.id,
             dep_name='foo', distance=3,
             prev_epoch=0, prev_version='1.2', prev_release='3',
             curr_epoch=0, curr_version='4.5', curr_release='6',
-        ))
+        )
         # baz was fixed
         b1 = self.prepare_build('baz', False)
         b2 = self.prepare_build('baz', True)
-        self.db.add(AppliedChange(
+        self.prepare_depchange(
             build_id=b2.id,
             dep_name='foo', distance=3,
             prev_epoch=0, prev_version='1.2', prev_release='3',
             curr_epoch=0, curr_version='4.5', curr_release='6',
-        ))
+        )
         # xyzzy failure is not related
         b1 = self.prepare_build('xyzzy', True)
         b2 = self.prepare_build('xyzzy', False)
-        self.db.add(AppliedChange(
+        self.prepare_depchange(
             build_id=b2.id,
             dep_name='foo', distance=3,
             prev_epoch=0, prev_version='0.5', prev_release='1',
             curr_epoch=0, curr_version='0.7', curr_release='2',
-        ))
+        )
         # abc was broken too
         b1 = self.prepare_build('abc', True)
         b2 = self.prepare_build('abc', False)
-        self.db.add(AppliedChange(
+        self.prepare_depchange(
             build_id=b2.id,
             dep_name='foo', distance=3,
             prev_epoch=0, prev_version='0.5', prev_release='1',
             curr_epoch=0, curr_version='4.5', curr_release='6',
-        ))
+        )
         # klm was broken too
         b1 = self.prepare_build('klm', True)
         b2 = self.prepare_build('klm', False)
-        self.db.add(AppliedChange(
+        self.prepare_depchange(
             build_id=b2.id,
             dep_name='foo', distance=3,
             prev_epoch=0, prev_version='1.2', prev_release='3',
             curr_epoch=666, curr_version='0.7', curr_release='2',
-        ))
+        )
         # ijk was broken too
         b1 = self.prepare_build('ijk', True)
         b2 = self.prepare_build('ijk', False)
-        self.db.add(AppliedChange(
+        self.prepare_depchange(
             build_id=b2.id,
             dep_name='foo', distance=3,
             prev_epoch=0, prev_version='0.5', prev_release='1',
             curr_epoch=666, curr_version='0.7', curr_release='2',
-        ))
+        )
         # pqr was broken too
         b1 = self.prepare_build('pqr', True)
         b2 = self.prepare_build('pqr', False)
-        self.db.add(AppliedChange(
+        self.prepare_depchange(
             build_id=b2.id,
             dep_name='foo', distance=3,
             prev_epoch=0, prev_version='3', prev_release='4',
             curr_epoch=0, curr_version='4', curr_release='5',
-        ))
+        )
         self.db.commit()
         reply = self.client.get(
             'affected-by/foo'+


### PR DESCRIPTION
Restructure applied_change table - instead of directly containing previous and current dependency EVR, it contains foreign key references into dependency table. This helps to reduce the table size to approximately 1/4 and allows to write more efficient queries against dependency changes for purposes of affected-by feature.

Note: unapplied_change table remains unchanged as it is already small, but I'm considering restructuring it as well for the sake of consistency.