### PR TITLE
[views] Fix skip_resolution being set to False when editing groups

### DIFF
--- a/test/frontend_test.py
+++ b/test/frontend_test.py
@@ -408,6 +408,24 @@ class FrontendTest(DBTest):
                 manual_priority=0,
                 arch_override='',
                 skip_resolution='on',
+                skip_resolution__present='1',
+            ),
+            follow_redirects=True,
+        )
+        self.assertEqual(200, reply.status_code)
+        self.assert_validated(reply)
+        self.assertEqual(True, package.skip_resolution)
+
+    @authenticate
+    def test_edit_package_skip_resolution_keep_old_value(self):
+        package = self.prepare_package('rnv')
+        package.skip_resolution = True
+        reply = self.client.post(
+            'package/rnv/edit',
+            data=dict(
+                collection_id=package.collection_id,
+                manual_priority=0,
+                arch_override='',
             ),
             follow_redirects=True,
         )


### PR DESCRIPTION
HTML POST request don't contain values of unchecked checkboxes, so
WTForms treats all not present BooleanFields as False.
Which causes skip_resolution to be set to False when editing package
groups, because they share a form. I introduced a custom field that uses
additional hidden field to determine checkbox presence. I could have as
well just split the forms, but I think this is more systematic solution,
as it also handles the (very rare, but possible) case when koschei is
upgraded and someone submits a form that gained additional field during
the upgrade.