### PR TITLE
Follow builddep logic for installing BuildRequires

### DIFF
--- a/koschei/backend/depsolve.py
+++ b/koschei/backend/depsolve.py
@@ -19,66 +19,20 @@
 
 from __future__ import print_function, absolute_import
 
-import re
 import hawkey
 
 from koschei.config import get_config
 
 
-def _get_best_selector(sack, dep):
-    # Based on get_best_selector in dnf's subject.py
-    # pylint: disable=len-as-condition
-
-    def is_glob_pattern(pattern):
-        return set(pattern) & set("*[?")
-
-    def first(iterable):
-        it = iter(iterable)
-        try:
-            return next(it)
-        except StopIteration:
-            return None
-
-    def _nevra_to_selector(sltr, nevra):
-        if nevra.name is not None:
-            if is_glob_pattern(nevra.name):
-                sltr.set(name__glob=nevra.name)
-            else:
-                sltr.set(name=nevra.name)
-        if nevra.version is not None:
-            evr = nevra.version
-            if nevra.epoch is not None and nevra.epoch > 0:
-                evr = "%d:%s" % (nevra.epoch, evr)
-            if nevra.release is None:
-                sltr.set(version=evr)
-            else:
-                evr = "%s-%s" % (evr, nevra.release)
-                sltr.set(evr=evr)
-        if nevra.arch is not None:
-            sltr.set(arch=nevra.arch)
-        return sltr
-
-    subj = hawkey.Subject(dep)
+def _get_builddep_selector(sack, dep):
+    # Try to find something by provides
     sltr = hawkey.Selector(sack)
-
-    nevra = first(subj.nevra_possibilities_real(sack, allow_globs=True))
-    if nevra:
-        s = _nevra_to_selector(sltr, nevra)
-        if len(s.matches()) > 0:
-            return s
-
-    # pylint: disable=E1101
-    reldep = first(subj.reldep_possibilities_real(sack))
-    if reldep:
-        dep = str(reldep)
-        s = sltr.set(provides=dep)
-        if len(s.matches()) > 0:
-            return s
-
-    if re.search(r'^\*?/', dep):
-        key = "file__glob" if is_glob_pattern(dep) else "file"
-        return sltr.set(**{key: dep})
-
+    sltr.set(provides=dep)
+    found = sltr.matches()
+    if not found and dep.startswith("/"):
+        # Nothing matches by provides and since it's file, try by files
+        sltr = hawkey.Selector(sack)
+        sltr.set(file=dep)
     return sltr
 
 
@@ -87,11 +41,11 @@ def run_goal(sack, br, group):
     goal = hawkey.Goal(sack)
     problems = []
     for name in group:
-        sltr = _get_best_selector(sack, name)
+        sltr = _get_builddep_selector(sack, name)
         # missing packages are silently skipped as in dnf
         goal.install(select=sltr)
     for r in br:
-        sltr = _get_best_selector(sack, r)
+        sltr = _get_builddep_selector(sack, r)
         # pylint: disable=E1103
         if not sltr.matches():
             problems.append("No package found for: {}".format(r))
@@ -122,7 +76,7 @@ def compute_dependency_distances(sack, br, deps):
     level = 1
     # pylint:disable=E1103
     pkgs_on_level = {x for r in br for x in
-                     _get_best_selector(sack, r).matches()}
+                     _get_builddep_selector(sack, r).matches()}
     while pkgs_on_level:
         for pkg in pkgs_on_level:
             dep = dep_map.get(pkg.name)

--- a/test/common.py
+++ b/test/common.py
@@ -25,6 +25,7 @@ import unittest
 import shutil
 import json
 import psycopg2
+import rpm
 import logging
 import requests
 import vcr
@@ -374,3 +375,7 @@ def service_ctor(name, plugin_name=None, plugin_endpoint='backend'):
         ctor = service.load_service(name)
         return ctor(*args, **kwargs)
     return inner
+
+
+def rpmvercmp(v1, v2):
+    return rpm.labelCompare((None, None, v1), (None, None, v2))

--- a/test/resolver_test.py
+++ b/test/resolver_test.py
@@ -596,3 +596,20 @@ class ResolverTest(DBTest):
             self.assertIsNotNone(deps)
             six.assertCountEqual(self, ['qt-x11', 'plasma-workspace', 'sni-qt', 'R'],
                                  [dep.name for dep in deps])
+
+    # rich deps used directly in BuildRequires
+    @skipIf(rpmvercmp(hawkey.VERSION, MINIMAL_HAWKEY_VERSION) < 0,
+            'Rich deps are not supported by this hawkey version')
+    def test_rich_build_requires(self):
+        with patch('koschei.backend.koji_util.get_build_group_cached', return_value=['R']):
+            sack = get_sack()
+            (resolved, problems, deps) = \
+                self.repo_resolver.resolve_dependencies(sack,
+                                                   ['(sni-qt(x86-64) if plasma-workspace)',
+                                                    'plasma-workspace'],
+                                                   ['R'])
+            six.assertCountEqual(self, [], problems)
+            self.assertTrue(resolved)
+            self.assertIsNotNone(deps)
+            six.assertCountEqual(self, ['plasma-workspace', 'sni-qt', 'R'],
+                                 [dep.name for dep in deps])

--- a/test/resolver_test.py
+++ b/test/resolver_test.py
@@ -23,10 +23,11 @@ from unittest import skipIf
 
 import hawkey
 import koji
+import rpm
 from mock import Mock, patch
 from sqlalchemy.orm import aliased
 
-from test.common import DBTest, RepoCacheMock
+from test.common import DBTest, RepoCacheMock, rpmvercmp
 from koschei import plugin
 from koschei.backend import koji_util
 from koschei.backend.services.resolver import DependencyCache
@@ -567,7 +568,7 @@ class ResolverTest(DBTest):
 
     # qt-x11 requires (sni-qt(x86-64) if plasma-workspace)
     # since plasma-workspace is not installed, sni-qt should not be instaled either
-    @skipIf(hawkey.VERSION < MINIMAL_HAWKEY_VERSION,
+    @skipIf(rpmvercmp(hawkey.VERSION, MINIMAL_HAWKEY_VERSION) < 0,
             'Rich deps are not supported by this hawkey version')
     def test_rich_deps(self):
         with patch('koschei.backend.koji_util.get_build_group_cached', return_value=['R']):
@@ -581,7 +582,7 @@ class ResolverTest(DBTest):
 
     # qt-x11 requires (sni-qt(x86-64) if plasma-workspace)
     # since plasma-workspace is installed, sni-qt should be instaled too
-    @skipIf(hawkey.VERSION < MINIMAL_HAWKEY_VERSION,
+    @skipIf(rpmvercmp(hawkey.VERSION, MINIMAL_HAWKEY_VERSION) < 0,
             'Rich deps are not supported by this hawkey version')
     def test_rich_deps2(self):
         with patch('koschei.backend.koji_util.get_build_group_cached', return_value=['R']):


### PR DESCRIPTION
For installing BuildRequires Koji uses DNF builddep plugin, which doesn't use get_best_selector().  It first tries to install BuildRequires as reldep and falls back to file if reldep doesn't match anything and dependency starts with a slash.

See: https://github.com/rpm-software-management/dnf-plugins-core/blob/2.1.4/plugins/builddep.py#L138-L153