### PR TITLE
Let the configuration specify time priority formula

### DIFF
--- a/config.cfg.template
+++ b/config.cfg.template
@@ -108,10 +108,11 @@ config = {
         # value that is added to package priority after a failed build that was
         # preceded by successful build (i.e. the package started to fail)
         "failed_build_priority": 200,
-        # values used for time priority calculation. See the source for the
-        # exact formula
-        "t0": 6,
-        "t1": 7 * 24,
+        # time priority formula:
+        # expects a function that takes the number of hours since the last
+        # rebuild (as sqlalchemy expression) and returns the desired time
+        # priority
+        "time_priority_fn": lambda hours: 5 * hours - 100,
     },
 
     # configuration of individual services

--- a/test/model_test.py
+++ b/test/model_test.py
@@ -172,7 +172,7 @@ class PackagePriorityTest(DBTest):
 
     def test_basic(self, _):
         # time priority for just completed build, no other values
-        self.verify_priority(-30)
+        self.verify_priority(-100)
 
     def test_coefficient(self, _):
         self.pkg.manual_priority = 10
@@ -180,21 +180,22 @@ class PackagePriorityTest(DBTest):
         self.pkg.dependency_priority = 40
         self.pkg.build_priority = 50
         self.pkg.collection.priority_coefficient = 0.5
-        self.verify_priority(10 + 20 + 0.5 * (-30 + 40 + 50))
+        self.verify_priority(10 + 20 + 0.5 * (-100 + 40 + 50))
 
     def test_time(self, _):
+        # now = '2017-10-10 10:00:00'
         # 2 h difference
         self.build.started = '2017-10-10 08:00:00'
-        self.verify_priority(-30)
+        self.verify_priority(-90)
         # 10 h difference
         self.build.started = '2017-10-10 00:00:00'
-        self.verify_priority(39.2446980024098)
+        self.verify_priority(-50)
         # 1 day difference
         self.build.started = '2017-10-9 00:00:00'
-        self.verify_priority(133.26248998925)
+        self.verify_priority(70)
         # 1 month difference
         self.build.started = '2017-9-10 00:00:00'
-        self.verify_priority(368.863607520133)
+        self.verify_priority(3550)
 
     def test_untracked(self, _):
         self.pkg.tracked = False
@@ -224,7 +225,7 @@ class PackagePriorityTest(DBTest):
     def test_resolution_skipped(self, _):
         self.pkg.resolved = None
         self.pkg.skip_resolution = True
-        self.verify_priority(-30)
+        self.verify_priority(-100)
 
 
 class StatsTest(DBTest):

--- a/test/test_config.cfg
+++ b/test/test_config.cfg
@@ -20,9 +20,6 @@ config = {
     "priorities": {
         "build_threshold": 256,
         "package_update": 20,
-        "t0": 6,
-        "t1": 7 * 24,
-        "package_state_change": 1
     },
     "services": {
         "polling": {


### PR DESCRIPTION
The configuration is executable python, so let's use the fact. Now the
administrator can specify custom formula for time priority calculation
as a function.

The default was changed to a simple linear function `5 * hours - 100`.
Sample values to illustrate the effect:
fn(0) = -100
fn(12) = -40
fn(24) = 20  # one day
fn(24 * 3) = 260  # reaches the default build threshold after 3 days
fn(24 * 7) = 740  # 1 week
fn(24 * 30) = 3500  # 1 month