### PR TITLE
Remove collection.dest_tag

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -449,7 +449,6 @@ class CreateOrEditCollectionCommand(object):
         target_info = koji_session.getBuildTarget(collection.target)
         if not target_info:
             sys.exit("Target not found in Koji")
-        collection.dest_tag = target_info['dest_tag_name']
         collection.build_tag = target_info['build_tag_name']
 
 

--- a/alembic/versions/780c0fed288f_remove_collection_dest_tag.py
+++ b/alembic/versions/780c0fed288f_remove_collection_dest_tag.py
@@ -1,0 +1,26 @@
+"""
+Remove collection.dest_tag
+
+Create Date: 2017-11-20 13:51:34.220593
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '780c0fed288f'
+down_revision = '0337520adb1e'
+
+from alembic import op
+
+
+def upgrade():
+    op.execute("""
+        ALTER TABLE collection DROP COLUMN dest_tag;
+    """)
+
+
+def downgrade():
+    op.execute("""
+        ALTER TABLE collection ADD COLUMN dest_tag text;
+        UPDATE collection SET dest_tag = build_tag;
+        ALTER TABLE collection ALTER COLUMN dest_tag SET NOT NULL;
+    """)

--- a/koschei/backend/__init__.py
+++ b/koschei/backend/__init__.py
@@ -110,7 +110,7 @@ def submit_build(session, package, arch_override=None):
     # secondary (internal redirect)
     srpm_res = koji_util.get_last_srpm(
         session.secondary_koji_for(package.collection),
-        package.collection.dest_tag,
+        package.collection.build_tag,
         name,
         relative=True
     )
@@ -143,7 +143,7 @@ def submit_build(session, package, arch_override=None):
 
 def get_newer_build_if_exists(session, package):
     [info] = session.secondary_koji_for(package.collection)\
-        .listTagged(package.collection.dest_tag, latest=True,
+        .listTagged(package.collection.build_tag, latest=True,
                     package=package.name, inherit=True) or [None]
     if info and util.is_build_newer(package.last_build, info):
         return info
@@ -462,10 +462,10 @@ def refresh_packages(session):
     """
     bases = {base.name: base for base
              in session.db.query(BasePackage.id, BasePackage.name)}
-    for collection in session.db.query(Collection.id, Collection.dest_tag,
+    for collection in session.db.query(Collection.id, Collection.build_tag,
                                        Collection.secondary_mode):
         koji_session = session.secondary_koji_for(collection)
-        koji_packages = koji_session.listPackages(tagID=collection.dest_tag,
+        koji_packages = koji_session.listPackages(tagID=collection.build_tag,
                                                   inherited=True)
         whitelisted = {p['package_name'] for p in koji_packages if not p['blocked']}
         packages = session.db.query(Package.id, Package.name, Package.blocked)\
@@ -590,7 +590,7 @@ def refresh_latest_builds(session):
     for collection in session.db.query(Collection):
         koji_session = session.secondary_koji_for(collection)
         build_infos = koji_session.listTagged(
-            collection.dest_tag,
+            collection.build_tag,
             latest=True,
             inherit=True,
         )

--- a/koschei/models.py
+++ b/koschei/models.py
@@ -65,7 +65,6 @@ class Collection(Base):
 
     # Koji configuration
     target = Column(String, nullable=False)
-    dest_tag = Column(String, nullable=False)
     build_tag = Column(String, nullable=False)
 
     # bugzilla template fields. If null, bug filling will be disabled

--- a/koschei/plugins/copr_plugin/backend/services/copr_scheduler.py
+++ b/koschei/plugins/copr_plugin/backend/services/copr_scheduler.py
@@ -98,7 +98,7 @@ class CoprScheduler(Service):
     def schedule_rebuild(self, rebuild):
         koji_session = self.session.koji(self.get_koji_id(rebuild.package.collection))
         srpm_url = koji_util.get_last_srpm(koji_session,
-                                           rebuild.package.collection.dest_tag,
+                                           rebuild.package.collection.build_tag,
                                            rebuild.package.name)[1]
         self.create_copr_project(rebuild.request, rebuild.copr_name)
         copr_build = copr_client.create_new_build(

--- a/koschei/plugins/repo_regen_plugin/backend.py
+++ b/koschei/plugins/repo_regen_plugin/backend.py
@@ -43,13 +43,12 @@ def poll_secondary_repo(session):
     primary = session.koji('primary')
     secondary = session.koji('secondary')
     for collection in db.query(Collection).filter_by(secondary_mode=True):
-        ensure_tag(primary, collection.dest_tag)
         ensure_tag(primary, collection.build_tag)
         target = primary.getBuildTarget(collection.target)
         if not target:
             log.info("Creating new secondary build target")
             primary.createBuildTarget(collection.target, collection.build_tag,
-                                      collection.dest_tag)
+                                      collection.build_tag)
             groups = secondary.getTagGroups(collection.build_tag)
             primary.multicall = True
             for group in groups:

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -35,7 +35,7 @@ class ApiTest(FrontendTest):
         self.prepare_build('xpp2', False)
         self.collection = Collection(
             name="epel7", display_name="EPEL 7", target="epel7",
-            dest_tag='epel7', build_tag="epel7-build", priority_coefficient=0.2,
+            build_tag="epel7-build", priority_coefficient=0.2,
             latest_repo_resolved=False, latest_repo_id=456,
         )
         self.db.add(self.collection)

--- a/test/common.py
+++ b/test/common.py
@@ -148,7 +148,7 @@ class DBTest(AbstractTest):
         self.pkg_name_counter = 1
         self.collection = Collection(
             name="f25", display_name="Fedora Rawhide", target="f25",
-            dest_tag='f25', build_tag="f25-build", priority_coefficient=1.0,
+            build_tag="f25-build", priority_coefficient=1.0,
             latest_repo_resolved=True, latest_repo_id=123,
         )
         self.session = KoscheiSessionMock()

--- a/test/data_test.py
+++ b/test/data_test.py
@@ -133,7 +133,6 @@ class DataTest(DBTest):
         new_build1 = self.prepare_build('maven', started=now)
         copy = Collection(
             name='copy', display_name='copy', target='a', build_tag='b',
-            dest_tag='c',
         )
         self.db.add(copy)
         prev_dep = Dependency(

--- a/test/model_test.py
+++ b/test/model_test.py
@@ -51,8 +51,7 @@ class GroupTest(DBTest):
     def test_group_cardinality_multiple_collections(self):
         group = self.prepare_group('xyzzy', content=['foo', 'bar', 'baz'])
         new_collection = Collection(name="new", display_name="New",
-                                    target='foo', dest_tag="tag2",
-                                    build_tag="build_tag2",
+                                    target='foo', build_tag="build_tag2",
                                     priority_coefficient=2.0)
         self.db.add(new_collection)
         self.db.commit()
@@ -74,8 +73,7 @@ class GroupTest(DBTest):
         self.prepare_packages('xalan-j2')[0].blocked = True
         self.db.commit()
         new_collection = Collection(name="new", display_name="New",
-                                    target='foo', dest_tag="tag2",
-                                    build_tag="build_tag2",
+                                    target='foo', build_tag="build_tag2",
                                     priority_coefficient=2.0)
         self.db.add(new_collection)
         self.db.commit()
@@ -91,8 +89,7 @@ class GroupTest(DBTest):
         self.prepare_packages('xalan-j2')[0].blocked = True
         self.db.commit()
         new_collection = Collection(name="new", display_name="New",
-                                    target='foo', dest_tag="tag2",
-                                    build_tag="build_tag2",
+                                    target='foo', build_tag="build_tag2",
                                     priority_coefficient=2.0)
         self.db.add(new_collection)
         self.db.commit()


### PR DESCRIPTION
Scheduler and polling are using dest_tag for querying SRPMs and real builds. For Rawhide it doesn't really matter, but for stable Fedoras, it can cause different effects:
- The builds are later moved by bodhi into different tags, so they disappear
- Build overrides don't have effect

Moreover, the dest_tag is often wrong, as it reflects the configuration by the time the collection was setup, which may differ from what is in koji now.

Honestly, I don't know why it was using dest_tag at all. I think it was like that from very early days and nobody questioned it ever since.

I think it should be using a single tag (build_tag) everywhere.