### PR TITLE
[depsolve] Skip unavailable packages in build group

### DIFF
--- a/koschei/backend/depsolve.py
+++ b/koschei/backend/depsolve.py
@@ -42,8 +42,9 @@ def run_goal(sack, br, group):
     problems = []
     for name in group:
         sltr = _get_builddep_selector(sack, name)
-        # missing packages are silently skipped as in dnf
-        goal.install(select=sltr)
+        if sltr.matches():
+            # missing packages are silently skipped as in dnf
+            goal.install(select=sltr)
     for r in br:
         sltr = _get_builddep_selector(sack, r)
         # pylint: disable=E1103

--- a/test/resolver_test.py
+++ b/test/resolver_test.py
@@ -275,6 +275,16 @@ class ResolverTest(DBTest):
                 self.build_resolver.process_builds(self.collection)
         self.assertTrue(foo_build.deps_resolved)
 
+    def test_nonexistent_in_group(self):
+        # nonexistent package in build group should be silently ignored
+        foo_build = self.prepare_foo_build()
+        with patch('koschei.backend.koji_util.get_build_group_cached',
+                   return_value=['R', 'nonexistent']):
+            with patch('koschei.backend.koji_util.get_rpm_requires',
+                       return_value=[['F', 'A']]):
+                self.build_resolver.process_builds(self.collection)
+        self.assertTrue(foo_build.deps_resolved)
+
     def test_resolution_fail(self):
         self.prepare_packages('bar')
         b = self.prepare_build('bar', True, repo_id=123, resolved=False)


### PR DESCRIPTION
Build group for EPEL 7 containts several packages which cannot be installed. When you use mock, dnf/yum just skips them with: `No match for group package "redhat-release-everything"`. Koschei needs to do this as well. It used to work, but broke recently.