### PR TITLE
[scheduler] Fix scheduling in secondary mode

### DIFF
--- a/koschei/backend/services/scheduler.py
+++ b/koschei/backend/services/scheduler.py
@@ -74,7 +74,7 @@ class Scheduler(Service):
                 package.collection.build_tag,
             )
             arches = koji_util.get_srpm_arches(
-                koji_session=koji_session,
+                koji_session=self.session.koji('secondary'),
                 all_arches=all_arches,
                 nvra=package.srpm_nvra,
                 arch_override=package.arch_override,


### PR DESCRIPTION
Scheduler needs to resolve SRPM headers from secondary instance as
that's where the SRPM is located.