### PR TITLE
Fix lock exception handling

### DIFF
--- a/koschei/backend/__init__.py
+++ b/koschei/backend/__init__.py
@@ -40,7 +40,6 @@ from koschei.plugin import dispatch_event
 class KoscheiBackendSession(KoscheiSession):
     def __init__(self):
         super(KoscheiBackendSession, self).__init__()
-        self._db_connection = None
         self._db = None
         self._koji_sessions = {}
         self._repo_cache = None
@@ -51,15 +50,12 @@ class KoscheiBackendSession(KoscheiSession):
     @property
     def db(self):
         if self._db is None:
-            self._db_connection = get_engine().connect()
-            self._db = Session(bind=self._db_connection)
+            self._db = Session()
         return self._db
 
     def close(self):
         if self._db:
-            self._db.close()
-        if self._db_connection:
-            self._db_connection.close()
+            self._db.close_connection()
 
     @property
     def build_from_repo_id(self):

--- a/test/locks_test.py
+++ b/test/locks_test.py
@@ -16,6 +16,8 @@
 #
 # Author: Michael Simacek <msimacek@redhat.com>
 
+from sqlalchemy.exc import ProgrammingError
+
 from test.common import DBTest
 
 from koschei.locks import (
@@ -46,6 +48,15 @@ class LocksTest(DBTest):
                 with self.assertRaises(Locked):
                     with pg_session_lock(self.s2.db, LOCK_REPO_RESOLVER, 1, block=False):
                         pass
+        # Try if it's unlocked
+        with pg_session_lock(self.s2.db, LOCK_REPO_RESOLVER, 1, block=False):
+            pass
+
+    def test_session_lock_exception_propagation(self):
+        with self.assertRaises(ProgrammingError):
+            with pg_session_lock(self.s1.db, LOCK_REPO_RESOLVER, 1, block=False):
+                # Execute some invalid statement
+                self.s1.db.execute("ALTER TABLE asdf RENAME TO sdfjk")
         # Try if it's unlocked
         with pg_session_lock(self.s2.db, LOCK_REPO_RESOLVER, 1, block=False):
             pass


### PR DESCRIPTION
Unlocking in `pg_session_lock` didn't always work even though it was executed in `finally`. The reason is that postgres refused to execute the unlock if the transaction was in failed state.