### PR TITLE
[resolver] Query the build group on secondary

### DIFF
--- a/koschei/backend/services/resolver.py
+++ b/koschei/backend/services/resolver.py
@@ -132,7 +132,7 @@ class Resolver(Service):
         """
         group = koji_util.get_build_group_cached(
             self.session,
-            self.session.koji('primary'),
+            self.session.koji('secondary'),
             collection.build_tag,
             collection.build_group,
             repo_id,


### PR DESCRIPTION
Primary and secondary should have the same build group. But they don't
have the same repos which we now use for getting the build group at
a particular point in time. So it needs to query the koji which owns the
repo, which is secondary. It is also more consistent - both repo and
build group are queried on secondary.