### PR TITLE
Fix build resolution

### DIFF
--- a/koschei/backend/services/build_resolver.py
+++ b/koschei/backend/services/build_resolver.py
@@ -161,6 +161,7 @@ class BuildResolver(Resolver):
                 if changes:
                     applied_changes = [self.change_to_applied(c) for c in changes]
                     self.db.execute(insert(AppliedChange, applied_changes))
+            prev_build.dependency_keys = None
 
     def store_dependencies(self, build, installs):
         """
@@ -176,13 +177,6 @@ class BuildResolver(Resolver):
         ]
         deps = self.dependency_cache.get_or_create_nevras(self.db, dep_tuples)
         build.dependency_keys = [dep.id for dep in deps]
-        # Remove previous build's dependency_keys to save space
-        (
-            self.db.query(Build)
-            .filter_by(package_id=build.package_id)
-            .filter(Build.repo_id < build.repo_id)
-            .update({'dependency_keys': None})
-        )
 
     def get_build_dependencies(self, build):
         """

--- a/test/resolver_test.py
+++ b/test/resolver_test.py
@@ -212,7 +212,7 @@ class ResolverTest(DBTest):
         self.assertIs(False, b.deps_resolved)
 
     def prepare_old_build(self):
-        old_build = self.prepare_foo_build(repo_id=555, version='3')
+        old_build = self.prepare_foo_build(repo_id=122, version='3')
         old_build.deps_resolved = True
         old_deps = FOO_DEPS[:]
         old_deps[2] = ('C', 1, '2', '1.fc22', 'x86_64')


### PR DESCRIPTION
Embarassing bug, which caused data loss (== no dependency changes reported) in production. Also there was a bug in the tests, which caused the bug to go undetected, despite the method was covered properly.

I already hotfixed production and triggered re-resolution of affected builds (which unfortunately won't work for builds whose repo is already dead).