### PR TITLE
[vargant] Set ansible compatibility mode to 2.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,8 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provision "ansible" do |ansible|
-      ansible.playbook = "aux/vagrant-playbook.yml"
+    ansible.compatibility_mode = "2.0"
+    ansible.playbook = "aux/vagrant-playbook.yml"
   end
 
   config.vm.post_up_message = <<-EOF


### PR DESCRIPTION
Set ansible compatibility mode to 2.0

Otherwise recent Vagrant would complain:

    Vagrant has automatically selected the compatibility mode '2.0'
    according to the Ansible version installed (2.4.3.0).
    
    Alternatively, the compatibility mode can be specified in your Vagrantfile:
    https://www.vagrantup.com/docs/provisioning/ansible_common.html#compatibility_mode
