### PR TITLE
[views] Highlight changed version component

### DIFF
--- a/static/koschei.css
+++ b/static/koschei.css
@@ -53,3 +53,5 @@ html { font-size: 14px; }
 .kk-copr-description           { padding-bottom: 20px; }
 
 .kk-untagged-build { filter: contrast(0.6); }
+
+.kk-evr-diff { font-weight: bold; }

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -227,8 +227,9 @@ affected by this dependency change"></i>
     </a>
     {{ change.dep_name }}
   </div>
+  {% set prev_evr, curr_evr = change.pretty_evrs %}
   <div class="col-sm-4">
-    {{ change.prev_evr or '' }}
+    {{ prev_evr }}
     <div class="float-right">
       {% if not change.prev_evr %}
       <i class="fa fa-plus" data-toggle="tooltip" data-placement="right"
@@ -245,7 +246,7 @@ affected by this dependency change"></i>
       {% endif %}
     </div>
   </div>
-  <div class="col-sm-3">{{ change.curr_evr or '' }}</div>
+  <div class="col-sm-3">{{ curr_evr }}</div>
   <div class="col-sm-1">
     {% if change.distance == 1 %}
     <span class="badge badge-pill badge-primary" data-toggle="tooltip" data-placement="right"


### PR DESCRIPTION
Highlight the leftmost components of dependency changes which changed.
Example:
1.[6]-3.fc28 -> 1.[7]-1.fc29 # [] denotes bold

This is to give better visual aid when scanning through large lists of
dependency changes. Especially after mass-rebuilds, when everything was
release bumped, but there may be packages which had been updated to new
upstream versions, and thus have higher probability of affecting the
build state.

Note that it works on string representation, so technically it's not
RPM-correct in cases like 7 -> 07. I think such cases are so rare that
it's not worth the complexity a RPM-correct solution would have had.