### PR TITLE
Normalize unapplied change

### DIFF
--- a/alembic/versions/8ab06d9c83e7_normalize_unappliedchange.py
+++ b/alembic/versions/8ab06d9c83e7_normalize_unappliedchange.py
@@ -1,0 +1,51 @@
+"""
+Normalize UnappliedChange
+
+Create Date: 2018-05-04 13:40:02.251000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '8ab06d9c83e7'
+down_revision = '0337520adb1e'
+
+from alembic import op
+
+
+def upgrade():
+    # UnappliedChange is transient data, it can be deleted and it will be
+    # regenerated on next resolver run
+    op.execute("""
+        DELETE FROM unapplied_change;
+        ALTER TABLE unapplied_change DROP COLUMN dep_name;
+        ALTER TABLE unapplied_change DROP COLUMN prev_epoch;
+        ALTER TABLE unapplied_change DROP COLUMN prev_version;
+        ALTER TABLE unapplied_change DROP COLUMN prev_release;
+        ALTER TABLE unapplied_change DROP COLUMN curr_epoch;
+        ALTER TABLE unapplied_change DROP COLUMN curr_version;
+        ALTER TABLE unapplied_change DROP COLUMN curr_release;
+        ALTER TABLE unapplied_change ADD COLUMN prev_dep_id integer
+            REFERENCES dependency(id);
+        ALTER TABLE unapplied_change ADD COLUMN curr_dep_id integer
+            REFERENCES dependency(id);
+        ALTER TABLE unapplied_change ADD CONSTRAINT unapplied_change_dep_id_check
+            CHECK ((COALESCE(prev_dep_id, 0) <> COALESCE(curr_dep_id, 0)));
+        CREATE INDEX ix_unapplied_change_prev_dep_id ON unapplied_change(prev_dep_id);
+        CREATE INDEX ix_unapplied_change_curr_dep_id ON unapplied_change(curr_dep_id);
+    """)
+
+
+def downgrade():
+    op.execute("""
+        DELETE FROM unapplied_change;
+        ALTER TABLE unapplied_change DROP CONSTRAINT unapplied_change_dep_id_check;
+        ALTER TABLE unapplied_change DROP COLUMN prev_dep_id;
+        ALTER TABLE unapplied_change DROP COLUMN curr_dep_id;
+        ALTER TABLE unapplied_change ADD COLUMN dep_name character varying NOT NULL;
+        ALTER TABLE unapplied_change ADD COLUMN prev_epoch integer;
+        ALTER TABLE unapplied_change ADD COLUMN prev_version character varying;
+        ALTER TABLE unapplied_change ADD COLUMN prev_release character varying;
+        ALTER TABLE unapplied_change ADD COLUMN curr_epoch integer;
+        ALTER TABLE unapplied_change ADD COLUMN curr_version character varying;
+        ALTER TABLE unapplied_change ADD COLUMN curr_release character varying;
+    """)

--- a/koschei/backend/services/repo_resolver.py
+++ b/koschei/backend/services/repo_resolver.py
@@ -238,15 +238,11 @@ class RepoResolver(Resolver):
                 prev_build = self.get_build_for_comparison(package)
                 if prev_build and prev_build.dependency_keys:
                     prev_deps = self.dependency_cache.get_by_ids(
-                        self.db, prev_build.dependency_keys
+                        prev_build.dependency_keys
                     )
                     changes = self.create_dependency_changes(
                         prev_deps, curr_deps, package_id=package.id,
                     )
-                    # UnappliedChange doesn't contain arch
-                    for change in changes:
-                        del change['prev_arch']
-                        del change['curr_arch']
             results.append(ResolutionOutput(
                 package=package,
                 prev_resolved=package.resolved,

--- a/test/resolver_test.py
+++ b/test/resolver_test.py
@@ -247,12 +247,14 @@ class ResolverTest(DBTest):
         foo = self.db.query(Package).filter_by(name='foo').first()
         self.assertTrue(foo.resolved)
         self.assertEqual(20, foo.dependency_priority)
-        expected_changes = [(foo.id, 'C', 1, 1, '2', '3', '1.fc22', '1.fc22', 2),
-                            (foo.id, 'E', None, 0, None, '0.1', None, '1.fc22.1', 2)]
-        c = UnappliedChange
-        actual_changes = self.db.query(c.package_id, c.dep_name, c.prev_epoch,
-                                       c.curr_epoch, c.prev_version, c.curr_version,
-                                       c.prev_release, c.curr_release, c.distance).all()
+        expected_changes = [
+            ('C', 2, RpmEVR(1, '2', '1.fc22'), RpmEVR(1, '3', '1.fc22')),
+            ('E', 2, None, RpmEVR(0, '0.1', '1.fc22.1')),
+        ]
+        actual_changes = [
+            (c.dep_name, c.distance, c.prev_evr, c.curr_evr)
+            for c in foo.unapplied_changes
+        ]
         self.assertCountEqual(expected_changes, actual_changes)
         resolution_change = self.db.query(ResolutionChange)\
             .filter_by(package_id=foo.id)\


### PR DESCRIPTION
Instead of directly containing the NEVRs in UnappliedChange, reference the Dependency table. This mirrors what I did for AppliedChange. The consistency helped me to drop some ugly glue code.