### PR TITLE
Port to new hawkey

### DIFF
--- a/koschei/backend/depsolve.py
+++ b/koschei/backend/depsolve.py
@@ -71,13 +71,17 @@ def run_goal(sack, br, group):
             problems.append("No package found for: {}".format(r))
         else:
             goal.install(select=sltr)
-    if not problems:
-        kwargs = {}
-        if get_config('dependency.ignore_weak_deps'):
-            kwargs = {'ignore_weak_deps': True}
-        resolved = goal.run(**kwargs)
-        return resolved, goal.problems, goal.list_installs() if resolved else None
-    return False, problems, None
+    kwargs = {}
+    if get_config('dependency.ignore_weak_deps'):
+        kwargs = {'ignore_weak_deps': True}
+    goal.run(**kwargs)
+    for first, *rest in goal.problem_rules():
+        problems.append(
+            f"Problem: {first}" +
+            ''.join(f'\n - {problem}' for problem in rest)
+        )
+    resolved = not problems
+    return resolved, problems, goal.list_installs() if resolved else None
 
 
 class DependencyWithDistance(object):

--- a/koschei/backend/repo_util.py
+++ b/koschei/backend/repo_util.py
@@ -94,5 +94,5 @@ def load_sack(repo_dir, repo_descriptor, download=False):
     sack = hawkey.Sack(arch=for_arch, cachedir=cache_dir)
     repo = get_repo(repo_dir, repo_descriptor, download)
     if repo:
-        sack.load_yum_repo(repo, load_filelists=True, build_cache=download)
+        sack.load_repo(repo, load_filelists=True, build_cache=download)
         return sack

--- a/koschei/frontend/model_additions.py
+++ b/koschei/frontend/model_additions.py
@@ -24,12 +24,12 @@ and adds few model specific global functions to templates.
 
 import re
 
-from flask import url_for
+from flask import url_for, escape
 from jinja2 import Markup
 
 from koschei.frontend.base import app
 from koschei.models import (
-    Package, Build, ResolutionChange, AppliedChange, UnappliedChange,
+    Package, Build, ResolutionChange, AppliedChange, UnappliedChange, ResolutionProblem,
 )
 
 
@@ -153,6 +153,13 @@ def resolution_change_css_class(resolution_change):
 
 
 ResolutionChange.css_class = property(resolution_change_css_class)
+
+
+def problem_html(self):
+    return str(escape(str(self))).replace('\n', '<br>')
+
+
+ResolutionProblem.__html__ = problem_html
 
 
 EVR_SEPARATORS_RE = re.compile(r'([-._~])')


### PR DESCRIPTION
Stop using methods that were removed in new libdnf/hawkey.
Changes the format of dependency problems to a more verbose one which
mostly matches what dnf prints.