### PR TITLE
[models] Packages shouldn't be tracked by default

### DIFF
--- a/koschei/models.py
+++ b/koschei/models.py
@@ -297,7 +297,8 @@ class Package(Base):
     # when user explicitly asks for them, their builds are polled depending on
     # `poll_untracked` attribute of the collection. They are not resolved and no builds
     # submitted for them.
-    tracked = Column(Boolean, nullable=False, server_default=true())
+    # TODO migrations
+    tracked = Column(Boolean, nullable=False, server_default=false())
     # Whether the package is blocked in Koji. Blocked packages should not be considered by
     # anything in Koschei. They're kept for the case if they become unblocked.
     blocked = Column(Boolean, nullable=False, server_default=false())

--- a/test/common.py
+++ b/test/common.py
@@ -291,7 +291,7 @@ class DBTest(AbstractTest):
         self.db.commit()
         return collection
 
-    def prepare_package(self, name=None, collection=None, **kwargs):
+    def prepare_package(self, name=None, collection=None, tracked=True, **kwargs):
         if 'collection_id' not in kwargs:
             if collection is None:
                 collection = self.collection
@@ -301,7 +301,7 @@ class DBTest(AbstractTest):
         base = self.db.query(BasePackage).filter_by(name=name).first()
         if not base:
             base = BasePackage(name=name)
-        pkg = Package(name=name, base=base, collection=collection, **kwargs)
+        pkg = Package(name=name, base=base, collection=collection, tracked=tracked, **kwargs)
         self.db.add(pkg)
         self.db.commit()
         return pkg


### PR DESCRIPTION
Fixes #278 

Remainder: add migrations upon merging this PR.