### PR TITLE
[admin] Don't try to resolve user name if SUDO_USER is set

### DIFF
--- a/koschei/admin.py
+++ b/koschei/admin.py
@@ -41,7 +41,9 @@ class KoscheiAdminSession(backend.KoscheiBackendSession):
         self.log = logging.getLogger('koschei.admin')
 
     def log_user_action(self, message, **kwargs):
-        username = os.environ.get('SUDO_USER', pwd.getpwuid(os.getuid()).pw_name)
+        username = os.environ.get('SUDO_USER')
+        if not username:
+            username = pwd.getpwuid(os.getuid()).pw_name
         user = get_or_create(self.db, User, name=username)
         self.db.add(LogEntry(environment='admin', user=user, message=message, **kwargs))
         print(message)


### PR DESCRIPTION
Fixes #282

OpenShift-created UIDs don't have corresponding user names.  Koschei
would try to eagerly resolve user name, even if SUDO_USER was set.

This change prevents crash in OpenShift with error like:
KeyError: 'getpwuid(): uid not found: 1000550000'