### PR TITLE
[package-detail] Fix Koji build URL

### DIFF
--- a/templates/package-detail.html
+++ b/templates/package-detail.html
@@ -267,7 +267,7 @@
             <div class="row">
               <div class="col-sm-12">
                 Real build:
-                <a href="{{ secondary_koji_url(package.collection) }}/search?match=&type=build&terms={{ package.name | urlencode }}-{{ build.version | urlencode }}-{{ build.release | urlencode }}">{{ package.name }}-{{ build.version }}-{{ build.release }}</a>
+                <a href="{{ secondary_koji_url(package.collection) }}/search?match=exact&type=build&terms={{ package.name | urlencode }}-{{ build.version | urlencode }}-{{ build.release | urlencode }}">{{ package.name }}-{{ build.version }}-{{ build.release }}</a>
               </div>
             </div>
             {% endif %}


### PR DESCRIPTION
Currently the URL sets the "match" parameter to an empty string, which is rejected by Koji:

    An error has occurred in the web interface code. This could be due to a bug or a configuration issue.
    koji.GenericError: No such match type: ''

Fix the URL template by passing "match=exact" instead, which works as intended.